### PR TITLE
Feat/#9:chat ws

### DIFF
--- a/cluvr-chat/build.gradle
+++ b/cluvr-chat/build.gradle
@@ -38,6 +38,15 @@ dependencies {
 
     // WebSocket + STOMP
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+    // MySQL
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'  // JPA 사용
+    runtimeOnly 'com.mysql:mysql-connector-j'  // MySQL JDBC 드라이버
+
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5' // jjwt-api 라이브러리 버전 지정
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5' // jjwt-impl 라이브러리 버전 지정 (런타임에만 필요)
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5' // jjwt-jackson 라이브러리 버전 지정 (Jackson과 연동할 때 필요)
 }
 
 tasks.named('test') {

--- a/cluvr-chat/build.gradle
+++ b/cluvr-chat/build.gradle
@@ -1,13 +1,22 @@
 plugins {
     id 'java'
+    id 'org.springframework.boot' version '3.5.0'
+    id 'io.spring.dependency-management' version '1.1.7'
+    id 'checkstyle'
+}
+
+checkstyle {
+    // 규칙이 어긋나는 코드가 하나라도 있을 경우 빌드 fail을 내고 싶다면 이 선언을 추가
+    maxWarnings = 0
+    //rule 및 suppressions xml파일 위치 명시
+    configFile = file("${rootDir}/naver-checkstyle-rules.xml")
+    configProperties = ["suppressionFile": "${rootDir}/naver-checkstyle-suppressions.xml"]
+    // checkstyle 버전 8.24 이상 선언
+    toolVersion = "8.24"
 }
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
-
-repositories {
-    mavenCentral()
-}
 
 java {
     toolchain {
@@ -15,15 +24,22 @@ java {
     }
 }
 
-dependencies {
-    testImplementation platform('org.junit:junit-bom:5.10.0')
-    testImplementation 'org.junit.jupiter:junit-jupiter'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-
-
+repositories {
+    mavenCentral()
 }
 
-test {
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // MongoDB 추가
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+
+    // WebSocket + STOMP
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+}
+
+tasks.named('test') {
     useJUnitPlatform()
 }

--- a/cluvr-chat/src/main/java/com/example/Main.java
+++ b/cluvr-chat/src/main/java/com/example/Main.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Main {
+
+	public static void main(String[] args) {
+		SpringApplication.run(Main.class, args);
+	}
+}

--- a/cluvr-chat/src/main/java/com/example/Main.java
+++ b/cluvr-chat/src/main/java/com/example/Main.java
@@ -2,7 +2,9 @@ package com.example;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class Main {
 

--- a/cluvr-chat/src/main/java/com/example/chat/config/RestTemplateConfig.java
+++ b/cluvr-chat/src/main/java/com/example/chat/config/RestTemplateConfig.java
@@ -10,7 +10,7 @@ import org.springframework.web.client.RestTemplate;
  * 1. 다른 서버에 api 요청할 때(권한, 데이터 확인, 사용자 정보 불러오기 등) 사용
  * 2. 채팅 서버 DB에 없는 정보가 필요할 때(ex : userName, profileUrl등)
  *
- * @author 박선영
+ * @author Tcimel
  */
 
 @Configuration

--- a/cluvr-chat/src/main/java/com/example/chat/config/RestTemplateConfig.java
+++ b/cluvr-chat/src/main/java/com/example/chat/config/RestTemplateConfig.java
@@ -1,0 +1,22 @@
+package com.example.chat.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * 설명:
+ * RestTemplate 이란
+ * 1. 다른 서버에 api 요청할 때(권한, 데이터 확인, 사용자 정보 불러오기 등) 사용
+ * 2. 채팅 서버 DB에 없는 정보가 필요할 때(ex : userName, profileUrl등)
+ *
+ * @author 박선영
+ */
+
+@Configuration
+public class RestTemplateConfig {
+	@Bean
+	public RestTemplate restTemplate() {
+		return new RestTemplate();
+	}
+}

--- a/cluvr-chat/src/main/java/com/example/chat/config/WebConfig.java
+++ b/cluvr-chat/src/main/java/com/example/chat/config/WebConfig.java
@@ -4,6 +4,22 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+/**
+ * 설명:
+ * http://localhost:63342에서 실행되는 프론트엔드와 CORS 문제 없이 통신할 수 있도록 설정된 Spring의 CORS 설정 클래스
+ * IntelliJ에서 HTML 파일을 실행하면 임의의 포트를 지정해 임시 웹 서버를 띄우는데, 그게 64452
+ * <p>
+ * CORS(Cross-Origin Resource Sharing)는 서로 다른 출처(origin) 간에 리소스를 주고받을 수 있도록 브라우저가 허용하는 정책
+ * 프론트엔드가 http://localhost:64452에서 실행되고, 백엔드(Spring)가 http://localhost:8080이라면, 이 둘은 “다른 origin”
+ * <p>
+ * Origin = 프로토콜 + 호스트 + 포트
+ * 예시 1:
+ * 주소: http://localhost:8080
+ * 프로토콜: http
+ * 호스트: localhost
+ * 포트: 8080
+ */
+
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 	@Override

--- a/cluvr-chat/src/main/java/com/example/chat/config/WebConfig.java
+++ b/cluvr-chat/src/main/java/com/example/chat/config/WebConfig.java
@@ -1,0 +1,17 @@
+package com.example.chat.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+	@Override
+	public void addCorsMappings(CorsRegistry registry) {
+		registry.addMapping("/**")
+			.allowedOrigins("http://localhost:63342")
+			.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS") // 허용할 HTTP 메서드
+			.allowedHeaders("*")
+			.allowCredentials(true);
+	}
+}

--- a/cluvr-chat/src/main/java/com/example/chat/config/WebSocketConfig.java
+++ b/cluvr-chat/src/main/java/com/example/chat/config/WebSocketConfig.java
@@ -1,0 +1,31 @@
+package com.example.chat.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+	@Override
+	public void registerStompEndpoints(StompEndpointRegistry registry) {
+		// 클라이언트가 연결할 엔드포인트 (SockJS 지원)
+		registry.addEndpoint("/cluvr-chat")
+			.setAllowedOriginPatterns("*")
+			// 나중에 특정 url 요청만 접근하도록 할 때 이부분 변경 : setAllowedOriginPatterns("https://www.cluvr.com")
+			// 또는 .setAllowedOriginPatterns("https://cluvr.com", "http://localhost:3000")
+			.withSockJS();
+	}
+
+	@Override
+	public void configureMessageBroker(MessageBrokerRegistry registry) {
+		// pub은 클라이언트 -> 서버 전송 prefix
+		registry.setApplicationDestinationPrefixes("/chat");
+
+		// sub은 서버 -> 클라이언트 브로드캐스트 prefix
+		registry.enableSimpleBroker("/sub");
+	}
+}

--- a/cluvr-chat/src/main/java/com/example/chat/config/WebSocketConfig.java
+++ b/cluvr-chat/src/main/java/com/example/chat/config/WebSocketConfig.java
@@ -6,6 +6,8 @@ import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBr
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
+// WebSocketMessageBrokerConfigurer :
+// WebSocket의 엔드포인트, 메시지 브로커, 라우팅 방식 설정 제공 클래스
 @Configuration
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
@@ -20,6 +22,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 			.withSockJS();
 	}
 
+	// 메시지가 어디로 전송되고(subscribe), 어디에서 수신되고(send) 할지를 설정하는 메서드
 	@Override
 	public void configureMessageBroker(MessageBrokerRegistry registry) {
 		// pub은 클라이언트 -> 서버 전송 prefix
@@ -28,4 +31,35 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 		// sub은 서버 -> 클라이언트 브로드캐스트 prefix
 		registry.enableSimpleBroker("/sub");
 	}
+	// Redis Pub/Sub, RabbitMQ, Kafka 같은 외부 브로커 설정 가능
+	// RabbitMQ 브로커 사용 예제 : RabbitMQ (STOMP 지원 브로커)
+	/*@Override
+	public void configureMessageBroker(MessageBrokerRegistry registry) {
+		registry.setApplicationDestinationPrefixes("/chat");
+
+		registry.enableStompBrokerRelay("/sub")
+			.setRelayHost("localhost")
+			.setRelayPort(61613)
+			.setClientLogin("guest")
+			.setClientPasscode("guest");
+	}*/
+
+	// STOMP를 지원하는 외부 브로커(RabbitMQ, ActiveMQ 등)와 직접 연결하는 방식
+	// enableStompBrokerRelay() 는 “브로커를 내장하지 말고 외부한테 맡겨”라는 뜻
+
+	// Redis Pub/Sub or Kafka 사용 예제
+	// 컨트롤러에서 설정 필요
+	// WebSocket 브로커가 직접 지원하지 않기 때문에 직접 메시지를 중간 처리해야 함.
+	// 즉, configureMessageBroker()보다는 메시지 처리 로직 내부에서 Redis/Kafka를 연동 필요
+	/*@MessageMapping("/room/{roomId}")
+	public void handleMessage(@Payload ChatMessage message) {
+		// 1. 메시지 Redis로 publish
+		redisPublisher.publish("room:" + message.getRoomId(), message);
+
+		// 2. 또는 Kafka로 전송
+		kafkaTemplate.send("chat-room-" + message.getRoomId(), message);
+	}*/
+
+	// 그리고 Redis/Kafka 리스너는 그 메시지를 받아서 다시 WebSocket으로 전달:
+	// messagingTemplate.convertAndSend("/sub/room/" + roomId, message);
 }

--- a/cluvr-chat/src/main/java/com/example/chat/controller/ChatController.java
+++ b/cluvr-chat/src/main/java/com/example/chat/controller/ChatController.java
@@ -1,11 +1,27 @@
 package com.example.chat.controller;
 
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
-import com.example.chat.dto.request.ChatMessageDto;
+import com.example.chat.dto.request.ChatMessageRequestDto;
+import com.example.chat.dto.request.ChatRoomRequestDto;
+import com.example.chat.dto.request.CreateChatRoomRequestDto;
+import com.example.chat.dto.response.ChatRoomResponseDto;
+import com.example.chat.entity.ChatLog;
+import com.example.chat.entity.ChatRoomUser;
+import com.example.chat.enums.ClubRole;
+import com.example.chat.service.ChatService;
+import com.example.global.response.response.BaseResponse;
+import com.example.global.response.response.ResponseCode;
 
 import lombok.RequiredArgsConstructor;
 
@@ -14,10 +30,100 @@ import lombok.RequiredArgsConstructor;
 public class ChatController {
 
 	private final SimpMessagingTemplate messagingTemplate;
+	private final ChatService chatService;
+
+	@PostMapping("club/{clubId}/chat/room/join")
+	public ResponseEntity<BaseResponse<?>> joinChatRoom(
+		@PathVariable Long clubId,
+		@RequestBody Long userId
+	) {
+		chatService.join(clubId, userId);
+		return ResponseEntity.ok(BaseResponse.success(ResponseCode.OK));
+	}
+
+	@GetMapping("/room/{roomId}/users")
+	public ResponseEntity<BaseResponse<List<ChatRoomUser>>> getUserInRoom(@PathVariable Long roomId) {
+		List<ChatRoomUser> users = chatService.getUserInRoom(roomId);
+		return ResponseEntity.ok(BaseResponse.success(users, ResponseCode.OK));
+	}
 
 	@MessageMapping("/message") // /pub/chat/message
-	public void sendMessage(@Payload ChatMessageDto chatMessageDto) {
-		String roomId = "/sub/chat/room/" + chatMessageDto.getRoomId();
-		messagingTemplate.convertAndSend(roomId, chatMessageDto);
+	public void sendMessage(@Payload ChatMessageRequestDto request) {
+		String roomId = "/sub/chat/room/" + request.getRoomId();
+		chatService.saveMessage(request); // 채팅 로그 몽고디비에 저장
+		messagingTemplate.convertAndSend(roomId, request); // 브로드 캐스트
 	}
+
+	/**
+	 * 설명: {채팅 메세지 불러오는 메서드}
+	 * <p>
+	 * [고도화 할 때 입장한 후 부터의 메세지 캐싱 필요]
+	 *
+	 * @param clubId
+	 * @param roomId
+	 * @return roomId에 해당하는 채팅 메세지
+	 * @author {박선영}
+	 */
+
+	@GetMapping("/club/{clubId}/chat/{roomId}")
+	public ResponseEntity<BaseResponse<List<ChatLog>>> getMessages(
+		@PathVariable Long clubId,
+		@PathVariable Long roomId
+	) {
+		List<ChatLog> messages = chatService.getMessages(roomId);
+		return ResponseEntity.ok(BaseResponse.success(messages, ResponseCode.OK));
+	}
+
+	/**
+	 * 설명: 채팅방 만들기
+	 * <p>
+	 * 생성할 때, 클럽 Id, 만든 user Id, 생성을 요청한 user의 클럽 role 필요
+	 * 유저는 클럽장, 매니저, MEMBER 역할이 있고 클럽장과 매니저 등급만 채팅방 생성 가능
+	 *
+	 * @param CreateChatRoomRequestDto {설명: 채팅방 생성에 필요한 dto}
+	 * @return {생성 완료 시 ResponseCode.CREATED 반환}
+	 * @throws {생성 권한이 없을 경우 권한이 없다는 안내 메세지 반환}
+	 * @author {박선영}
+	 */
+
+	@PostMapping("/chat/create")
+	public ResponseEntity<BaseResponse<?>> createChatRoom(
+		@RequestBody CreateChatRoomRequestDto request) {
+		if (request.getRole() == ClubRole.MEMBER) {
+			return ResponseEntity.ok(BaseResponse.error(ResponseCode.ACCESS_DENIED, "권한이 없습니다. 관리자에게 문의하세요."));
+		}
+		chatService.createChatRoom(request);
+		return ResponseEntity.ok(BaseResponse.success(ResponseCode.CREATED));
+	}
+
+	/**
+	 * 설명: {채팅방 조회}
+	 * 채팅방 조회 시 클럽원 역할에 따라 불러오는 리스트가 다름.
+	 * 채팅방 타입은 MANAGER, MEMBER 타입이 있는데
+	 * 클럽장과 매니저 역할은 모든 채팅방 리스트가 보이고
+	 * 유저에게는 MANAGER 타입의 채팅방이 보이면 안됨.
+	 * <p>
+	 * [고도화 때 접근하는 IP 설정 필요]
+	 * 방법 1 : IP 화이트리스트 설정 (필터 설정하기)
+	 * 방법 2 : X-INTERNAL_KEY 설정 추가 해당 키값이 없거나 같지 않을 경우 돌려보내기
+	 * 방법 3 : Spring Security 사용
+	 * <p>
+	 * 조회인데 Post를 한 이유
+	 * 외부에서 직접 URL 조작을 막고 싶은 경우, Body 안에 정보를 넣고 POST로 전달하는 방식이 일반적이라고 함.
+	 *
+	 * @param clubId              {설명: 채팅방 정보를 조회할 clubId 정보}
+	 * @param ChatRoomResponseDto {설명: 유저 Role에 해당하는 채팅방 리스트를 불러와야 하기 때문에, requestbody로 userId와 user의 role정보 전달 필요}
+	 * @return {clubId와 user의 role에 따른 채팅방 리스트 반환}
+	 * @author {박선영}
+	 */
+
+	@PostMapping("/club/{clubId}/chat/list")
+	public ResponseEntity<BaseResponse<List<ChatRoomResponseDto>>> getChatRooms(
+		@PathVariable Long clubId,
+		@RequestBody ChatRoomRequestDto request
+	) {
+		List<ChatRoomResponseDto> chatRooms = chatService.findChatRoomByClubAndRole(clubId, request);
+		return ResponseEntity.ok(BaseResponse.success(chatRooms, ResponseCode.OK));
+	}
+
 }

--- a/cluvr-chat/src/main/java/com/example/chat/controller/ChatController.java
+++ b/cluvr-chat/src/main/java/com/example/chat/controller/ChatController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import com.example.chat.dto.request.ChatMessageRequestDto;
 import com.example.chat.dto.request.ChatRoomRequestDto;
 import com.example.chat.dto.request.CreateChatRoomRequestDto;
+import com.example.chat.dto.request.JoinRequestDto;
 import com.example.chat.dto.response.ChatRoomResponseDto;
 import com.example.chat.entity.ChatLog;
 import com.example.chat.entity.ChatRoomUser;
@@ -24,7 +25,9 @@ import com.example.global.response.response.BaseResponse;
 import com.example.global.response.response.ResponseCode;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Controller
 @RequiredArgsConstructor
 public class ChatController {
@@ -32,12 +35,12 @@ public class ChatController {
 	private final SimpMessagingTemplate messagingTemplate;
 	private final ChatService chatService;
 
-	@PostMapping("club/{clubId}/chat/room/join")
+	@PostMapping("club/{clubId}/chat/join")
 	public ResponseEntity<BaseResponse<?>> joinChatRoom(
 		@PathVariable Long clubId,
-		@RequestBody Long userId
+		@RequestBody JoinRequestDto request
 	) {
-		chatService.join(clubId, userId);
+		chatService.join(clubId, request);
 		return ResponseEntity.ok(BaseResponse.success(ResponseCode.OK));
 	}
 
@@ -49,9 +52,7 @@ public class ChatController {
 
 	@MessageMapping("/message") // /pub/chat/message
 	public void sendMessage(@Payload ChatMessageRequestDto request) {
-		String roomId = "/sub/chat/room/" + request.getRoomId();
-		chatService.saveMessage(request); // 채팅 로그 몽고디비에 저장
-		messagingTemplate.convertAndSend(roomId, request); // 브로드 캐스트
+		chatService.broadcastMessage(request); // 채팅 로그 몽고디비에 저장
 	}
 
 	/**
@@ -62,7 +63,7 @@ public class ChatController {
 	 * @param clubId
 	 * @param roomId
 	 * @return roomId에 해당하는 채팅 메세지
-	 * @author {박선영}
+	 * @author Tcimel
 	 */
 
 	@GetMapping("/club/{clubId}/chat/{roomId}")
@@ -83,12 +84,13 @@ public class ChatController {
 	 * @param CreateChatRoomRequestDto {설명: 채팅방 생성에 필요한 dto}
 	 * @return {생성 완료 시 ResponseCode.CREATED 반환}
 	 * @throws {생성 권한이 없을 경우 권한이 없다는 안내 메세지 반환}
-	 * @author {박선영}
+	 * @author Tcimel
 	 */
 
 	@PostMapping("/chat/create")
 	public ResponseEntity<BaseResponse<?>> createChatRoom(
 		@RequestBody CreateChatRoomRequestDto request) {
+		log.info("방 생성 요청: {}", request);
 		if (request.getRole() == ClubRole.MEMBER) {
 			return ResponseEntity.ok(BaseResponse.error(ResponseCode.ACCESS_DENIED, "권한이 없습니다. 관리자에게 문의하세요."));
 		}
@@ -114,7 +116,7 @@ public class ChatController {
 	 * @param clubId              {설명: 채팅방 정보를 조회할 clubId 정보}
 	 * @param ChatRoomResponseDto {설명: 유저 Role에 해당하는 채팅방 리스트를 불러와야 하기 때문에, requestbody로 userId와 user의 role정보 전달 필요}
 	 * @return {clubId와 user의 role에 따른 채팅방 리스트 반환}
-	 * @author {박선영}
+	 * @author Tcimel
 	 */
 
 	@PostMapping("/club/{clubId}/chat/list")
@@ -122,6 +124,8 @@ public class ChatController {
 		@PathVariable Long clubId,
 		@RequestBody ChatRoomRequestDto request
 	) {
+		log.info("🥕🥕🥕 clubId = {}", clubId);
+		log.info("🥕🥕🥕 request = {}", request);
 		List<ChatRoomResponseDto> chatRooms = chatService.findChatRoomByClubAndRole(clubId, request);
 		return ResponseEntity.ok(BaseResponse.success(chatRooms, ResponseCode.OK));
 	}

--- a/cluvr-chat/src/main/java/com/example/chat/controller/ChatController.java
+++ b/cluvr-chat/src/main/java/com/example/chat/controller/ChatController.java
@@ -1,4 +1,23 @@
 package com.example.chat.controller;
 
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+import com.example.chat.dto.request.ChatMessageDto;
+
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequiredArgsConstructor
 public class ChatController {
+
+	private final SimpMessagingTemplate messagingTemplate;
+
+	@MessageMapping("/message") // /pub/chat/message
+	public void sendMessage(@Payload ChatMessageDto chatMessageDto) {
+		String roomId = "/sub/chat/room/" + chatMessageDto.getRoomId();
+		messagingTemplate.convertAndSend(roomId, chatMessageDto);
+	}
 }

--- a/cluvr-chat/src/main/java/com/example/chat/dto/request/ChatMessageDto.java
+++ b/cluvr-chat/src/main/java/com/example/chat/dto/request/ChatMessageDto.java
@@ -1,0 +1,13 @@
+package com.example.chat.dto.request;
+
+import com.example.chat.enums.MessageType;
+
+import lombok.Getter;
+
+@Getter
+public class ChatMessageDto {
+	private MessageType type;
+	private Long roomId;
+	private Long userId;
+	private String message;
+}

--- a/cluvr-chat/src/main/java/com/example/chat/dto/request/ChatMessageRequestDto.java
+++ b/cluvr-chat/src/main/java/com/example/chat/dto/request/ChatMessageRequestDto.java
@@ -3,11 +3,27 @@ package com.example.chat.dto.request;
 import com.example.chat.enums.MessageType;
 
 import lombok.Getter;
+import lombok.Setter;
 
+@Setter
 @Getter
 public class ChatMessageRequestDto {
 	private MessageType type;
 	private Long roomId;
 	private Long userId;
+	private String nickname;
 	private String message;
+
+	public ChatMessageRequestDto(MessageType type, Long roomId, Long userId, String nickname, String message) {
+		this.type = type;
+		this.roomId = roomId;
+		this.userId = userId;
+		this.nickname = nickname;
+		this.message = message;
+	}
+
+	public static ChatMessageRequestDto from(MessageType type, Long roomId, Long userId, String nickname,
+		String message) {
+		return new ChatMessageRequestDto(type, roomId, userId, nickname, message);
+	}
 }

--- a/cluvr-chat/src/main/java/com/example/chat/dto/request/ChatMessageRequestDto.java
+++ b/cluvr-chat/src/main/java/com/example/chat/dto/request/ChatMessageRequestDto.java
@@ -5,7 +5,7 @@ import com.example.chat.enums.MessageType;
 import lombok.Getter;
 
 @Getter
-public class ChatMessageDto {
+public class ChatMessageRequestDto {
 	private MessageType type;
 	private Long roomId;
 	private Long userId;

--- a/cluvr-chat/src/main/java/com/example/chat/dto/request/ChatRoomRequestDto.java
+++ b/cluvr-chat/src/main/java/com/example/chat/dto/request/ChatRoomRequestDto.java
@@ -1,0 +1,11 @@
+package com.example.chat.dto.request;
+
+import com.example.chat.enums.ClubRole;
+
+import lombok.Getter;
+
+@Getter
+public class ChatRoomRequestDto {
+	private Long userId;
+	private ClubRole role;
+}

--- a/cluvr-chat/src/main/java/com/example/chat/dto/request/ChatRoomRequestDto.java
+++ b/cluvr-chat/src/main/java/com/example/chat/dto/request/ChatRoomRequestDto.java
@@ -3,9 +3,22 @@ package com.example.chat.dto.request;
 import com.example.chat.enums.ClubRole;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Setter
 @Getter
+@NoArgsConstructor
 public class ChatRoomRequestDto {
 	private Long userId;
 	private ClubRole role;
+
+	public ChatRoomRequestDto(Long userId, ClubRole role) {
+		this.userId = userId;
+		this.role = role;
+	}
+
+	public static ChatRoomRequestDto from(Long userId, ClubRole role) {
+		return new ChatRoomRequestDto(userId, role);
+	}
 }

--- a/cluvr-chat/src/main/java/com/example/chat/dto/request/CreateChatRoomDto.java
+++ b/cluvr-chat/src/main/java/com/example/chat/dto/request/CreateChatRoomDto.java
@@ -1,5 +1,0 @@
-package com.example.chat.dto.request;
-
-public class CreateChatRoomDto {
-
-}

--- a/cluvr-chat/src/main/java/com/example/chat/dto/request/CreateChatRoomRequestDto.java
+++ b/cluvr-chat/src/main/java/com/example/chat/dto/request/CreateChatRoomRequestDto.java
@@ -1,0 +1,18 @@
+package com.example.chat.dto.request;
+
+import com.example.chat.enums.ClubRole;
+import com.example.chat.enums.RoomType;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CreateChatRoomRequestDto {
+	private Long clubId; // 클럽 ID (도메인 서버가 전달)
+	private RoomType type; // 채팅방 타입(MANAGER, MEMBER)
+	private Long userId; // 생성자 ID (도메인 서버가 전달)
+	private ClubRole role; // 해당 유저의 클럽에서의 role 정보 (LEADER, MANAGER, MEMBER)
+	private String name; // 채팅방 명
+	private String imageUrl;
+}

--- a/cluvr-chat/src/main/java/com/example/chat/dto/request/JoinRequestDto.java
+++ b/cluvr-chat/src/main/java/com/example/chat/dto/request/JoinRequestDto.java
@@ -1,0 +1,16 @@
+package com.example.chat.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class JoinRequestDto {
+	private Long userId;
+
+	public JoinRequestDto(Long userId) {
+		this.userId = userId;
+	}
+
+	public static JoinRequestDto from(Long userId) {
+		return new JoinRequestDto(userId);
+	}
+}

--- a/cluvr-chat/src/main/java/com/example/chat/dto/request/SendMessageDto.java
+++ b/cluvr-chat/src/main/java/com/example/chat/dto/request/SendMessageDto.java
@@ -1,5 +1,0 @@
-package com.example.chat.dto.request;
-
-public class SendMessageDto {
-
-}

--- a/cluvr-chat/src/main/java/com/example/chat/dto/response/ChatRoomResponseDto.java
+++ b/cluvr-chat/src/main/java/com/example/chat/dto/response/ChatRoomResponseDto.java
@@ -1,0 +1,27 @@
+package com.example.chat.dto.response;
+
+import com.example.chat.entity.ChatRoom;
+import com.example.chat.enums.RoomType;
+
+public class ChatRoomResponseDto {
+	private Long id;
+	private Long clubId;
+	private String name;
+	private RoomType type;
+
+	public ChatRoomResponseDto(Long id, Long clubId, String name, RoomType type) {
+		this.id = id;
+		this.clubId = clubId;
+		this.name = name;
+		this.type = type;
+	}
+
+	public static ChatRoomResponseDto from(ChatRoom room) {
+		return new ChatRoomResponseDto(
+			room.getId(),
+			room.getClubId(),
+			room.getName(),
+			room.getType()
+		);
+	}
+}

--- a/cluvr-chat/src/main/java/com/example/chat/dto/response/ChatRoomResponseDto.java
+++ b/cluvr-chat/src/main/java/com/example/chat/dto/response/ChatRoomResponseDto.java
@@ -3,6 +3,11 @@ package com.example.chat.dto.response;
 import com.example.chat.entity.ChatRoom;
 import com.example.chat.enums.RoomType;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
 public class ChatRoomResponseDto {
 	private Long id;
 	private Long clubId;

--- a/cluvr-chat/src/main/java/com/example/chat/dto/response/UserInfoResponseDto.java
+++ b/cluvr-chat/src/main/java/com/example/chat/dto/response/UserInfoResponseDto.java
@@ -1,0 +1,11 @@
+package com.example.chat.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class UserInfoResponseDto {
+	private Long userId;
+	private String nickname;
+	private String role;
+	private String imageUrl;
+}

--- a/cluvr-chat/src/main/java/com/example/chat/dto/response/UserInfoResponseDto.java
+++ b/cluvr-chat/src/main/java/com/example/chat/dto/response/UserInfoResponseDto.java
@@ -8,4 +8,15 @@ public class UserInfoResponseDto {
 	private String nickname;
 	private String role;
 	private String imageUrl;
+
+	public UserInfoResponseDto(Long userId, String nickname, String role, String imageUrl) {
+		this.userId = userId;
+		this.nickname = nickname;
+		this.role = role;
+		this.imageUrl = imageUrl;
+	}
+
+	public static UserInfoResponseDto from(Long userId, String nickname, String role, String imageUrl) {
+		return new UserInfoResponseDto(userId, nickname, role, imageUrl);
+	}
 }

--- a/cluvr-chat/src/main/java/com/example/chat/entity/ChatLog.java
+++ b/cluvr-chat/src/main/java/com/example/chat/entity/ChatLog.java
@@ -1,38 +1,32 @@
 package com.example.chat.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
+import java.time.LocalDateTime;
+
+import org.springframework.data.mongodb.core.mapping.Document;
+
 import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
-import jakarta.persistence.Table;
-import java.time.LocalDateTime;
-import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@Entity
-@Table(name = "chat_logs")
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Document(collation = "chat_log")
 public class ChatLog {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	private String id; // MongoDB에서 id는 String 값
 
-    private Long roomId;
-    private Long userId;
+	private Long roomId;
+	private Long userId;
 
-    @Lob
-    private String message;
+	@Lob
+	private String message;
 
-    private LocalDateTime createdAt;
+	private LocalDateTime createdAt;
 
-    public ChatLog(Long roomId, Long userId, String message, LocalDateTime createdAt) {
-        this.roomId = roomId;
-        this.userId = userId;
-        this.message = message;
-        this.createdAt = createdAt;
-    }
+	public ChatLog(Long roomId, Long userId, String message, LocalDateTime createdAt) {
+		this.roomId = roomId;
+		this.userId = userId;
+		this.message = message;
+		this.createdAt = createdAt;
+	}
 }

--- a/cluvr-chat/src/main/java/com/example/chat/entity/ChatLog.java
+++ b/cluvr-chat/src/main/java/com/example/chat/entity/ChatLog.java
@@ -16,7 +16,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@Document(collation = "chat_log")
+@Document("chat_log")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class ChatLog {
@@ -25,6 +25,7 @@ public class ChatLog {
 
 	private Long roomId;
 	private Long userId;
+	private String nickname;
 
 	@Lob
 	private String message;
@@ -34,11 +35,13 @@ public class ChatLog {
 
 	private LocalDateTime createdAt;
 
-	public ChatLog(Long roomId, Long userId, String message, MessageType type, LocalDateTime createdAt) {
+	public ChatLog(Long roomId, Long userId, String nickname, String message, MessageType type,
+		LocalDateTime createdAt) {
 		this.roomId = roomId;
 		this.userId = userId;
-		this.type = type;
+		this.nickname = nickname;
 		this.message = message;
+		this.type = type;
 		this.createdAt = createdAt;
 	}
 }

--- a/cluvr-chat/src/main/java/com/example/chat/entity/ChatLog.java
+++ b/cluvr-chat/src/main/java/com/example/chat/entity/ChatLog.java
@@ -4,14 +4,22 @@ import java.time.LocalDateTime;
 
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import com.example.chat.enums.MessageType;
+
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Document(collation = "chat_log")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class ChatLog {
-
 	@Id
 	private String id; // MongoDB에서 id는 String 값
 
@@ -21,11 +29,15 @@ public class ChatLog {
 	@Lob
 	private String message;
 
+	@Enumerated(EnumType.STRING)
+	private MessageType type; // ENTER, TALK, LEAVE
+
 	private LocalDateTime createdAt;
 
-	public ChatLog(Long roomId, Long userId, String message, LocalDateTime createdAt) {
+	public ChatLog(Long roomId, Long userId, String message, MessageType type, LocalDateTime createdAt) {
 		this.roomId = roomId;
 		this.userId = userId;
+		this.type = type;
 		this.message = message;
 		this.createdAt = createdAt;
 	}

--- a/cluvr-chat/src/main/java/com/example/chat/entity/ChatLog.java
+++ b/cluvr-chat/src/main/java/com/example/chat/entity/ChatLog.java
@@ -11,14 +11,12 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Document("chat_log")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class ChatLog {
 	@Id
 	private String id; // MongoDB에서 id는 String 값

--- a/cluvr-chat/src/main/java/com/example/chat/entity/ChatRoomUser.java
+++ b/cluvr-chat/src/main/java/com/example/chat/entity/ChatRoomUser.java
@@ -1,0 +1,46 @@
+package com.example.chat.entity;
+
+import java.time.LocalDateTime;
+
+import com.example.chat.enums.ClubRole;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "chat_room_user")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoomUser {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private Long clubId;
+	private Long roomId;
+	private Long userId;
+	private String nickname;
+
+	@Enumerated(EnumType.STRING)
+	private ClubRole clubRole;
+
+	private LocalDateTime joinedAt;
+
+	public ChatRoomUser(Long clubId, Long roomId, Long userId, String nickname, ClubRole clubRole,
+		LocalDateTime joinedAt) {
+		this.clubId = clubId;
+		this.roomId = roomId;
+		this.userId = userId;
+		this.nickname = nickname;
+		this.clubRole = clubRole;
+		this.joinedAt = joinedAt;
+	}
+}

--- a/cluvr-chat/src/main/java/com/example/chat/entity/ChatRoomUser.java
+++ b/cluvr-chat/src/main/java/com/example/chat/entity/ChatRoomUser.java
@@ -14,7 +14,9 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Setter
 @Getter
 @Entity
 @Table(name = "chat_room_user")

--- a/cluvr-chat/src/main/java/com/example/chat/enums/ClubRole.java
+++ b/cluvr-chat/src/main/java/com/example/chat/enums/ClubRole.java
@@ -1,0 +1,5 @@
+package com.example.chat.enums;
+
+public enum ClubRole {
+	LEADER, MANAGER, MEMBER
+}

--- a/cluvr-chat/src/main/java/com/example/chat/enums/ClubRole.java
+++ b/cluvr-chat/src/main/java/com/example/chat/enums/ClubRole.java
@@ -1,5 +1,8 @@
 package com.example.chat.enums;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+@JsonFormat(shape = JsonFormat.Shape.STRING)
 public enum ClubRole {
 	LEADER, MANAGER, MEMBER
 }

--- a/cluvr-chat/src/main/java/com/example/chat/enums/MessageType.java
+++ b/cluvr-chat/src/main/java/com/example/chat/enums/MessageType.java
@@ -1,5 +1,8 @@
 package com.example.chat.enums;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+@JsonFormat(shape = JsonFormat.Shape.STRING)
 public enum MessageType {
 	ENTER, TALK, LEAVE
 }

--- a/cluvr-chat/src/main/java/com/example/chat/enums/MessageType.java
+++ b/cluvr-chat/src/main/java/com/example/chat/enums/MessageType.java
@@ -1,0 +1,5 @@
+package com.example.chat.enums;
+
+public enum MessageType {
+	ENTER, TALK, LEAVE
+}

--- a/cluvr-chat/src/main/java/com/example/chat/enums/RoomType.java
+++ b/cluvr-chat/src/main/java/com/example/chat/enums/RoomType.java
@@ -1,8 +1,8 @@
 package com.example.chat.enums;
 
-import lombok.Getter;
+import com.fasterxml.jackson.annotation.JsonFormat;
 
-@Getter
+@JsonFormat(shape = JsonFormat.Shape.STRING)
 public enum RoomType {
-    MANAGER, MEMBER
+	MANAGER, MEMBER
 }

--- a/cluvr-chat/src/main/java/com/example/chat/repository/ChatLogRepository.java
+++ b/cluvr-chat/src/main/java/com/example/chat/repository/ChatLogRepository.java
@@ -1,8 +1,8 @@
 package com.example.chat.repository;
 
+import org.springframework.data.mongodb.repository.MongoRepository;
+
 import com.example.chat.entity.ChatLog;
 
-
-public interface ChatLogRepository extends
-    com.example.common.repository.BaseRepository<ChatLog, Long> {
+public interface ChatLogRepository extends MongoRepository<ChatLog, String> {
 }

--- a/cluvr-chat/src/main/java/com/example/chat/repository/ChatLogRepository.java
+++ b/cluvr-chat/src/main/java/com/example/chat/repository/ChatLogRepository.java
@@ -1,8 +1,11 @@
 package com.example.chat.repository;
 
+import java.util.List;
+
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 import com.example.chat.entity.ChatLog;
 
 public interface ChatLogRepository extends MongoRepository<ChatLog, String> {
+	List<ChatLog> findByRoomIdOrderByCreatedAtAsc(Long roomId);
 }

--- a/cluvr-chat/src/main/java/com/example/chat/repository/ChatRoomRepository.java
+++ b/cluvr-chat/src/main/java/com/example/chat/repository/ChatRoomRepository.java
@@ -1,8 +1,13 @@
 package com.example.chat.repository;
 
+import java.util.List;
+
 import com.example.chat.entity.ChatRoom;
+import com.example.chat.enums.RoomType;
+import com.example.common.repository.BaseRepository;
 
+public interface ChatRoomRepository extends BaseRepository<ChatRoom, Long> {
+	List<ChatRoom> findByClubId(Long clubId);
 
-public interface ChatRoomRepository extends
-    com.example.common.repository.BaseRepository<ChatRoom, Long> {
+	List<ChatRoom> findByClubIdAndType(Long clubId, RoomType type);
 }

--- a/cluvr-chat/src/main/java/com/example/chat/repository/ChatRoomUserRepository.java
+++ b/cluvr-chat/src/main/java/com/example/chat/repository/ChatRoomUserRepository.java
@@ -1,0 +1,12 @@
+package com.example.chat.repository;
+
+import java.util.List;
+
+import com.example.chat.entity.ChatRoomUser;
+import com.example.common.repository.BaseRepository;
+
+public interface ChatRoomUserRepository extends BaseRepository<ChatRoomUser, Long> {
+	boolean existsByRoomIdAndUserId(Long roomId, Long userId);
+
+	List<ChatRoomUser> findByRoomId(Long roomId);
+}

--- a/cluvr-chat/src/main/java/com/example/chat/repository/ChatRoomUserRepository.java
+++ b/cluvr-chat/src/main/java/com/example/chat/repository/ChatRoomUserRepository.java
@@ -9,4 +9,10 @@ public interface ChatRoomUserRepository extends BaseRepository<ChatRoomUser, Lon
 	boolean existsByRoomIdAndUserId(Long roomId, Long userId);
 
 	List<ChatRoomUser> findByRoomId(Long roomId);
+
+	ChatRoomUser findByRoomIdAndUserId(Long roomId, Long userId);
+
+	void deleteByRoomIdAndUserId(Long roomId, Long userId);
+
+	List<ChatRoomUser> findByUserId(Long userId);
 }

--- a/cluvr-chat/src/main/java/com/example/chat/service/ChatService.java
+++ b/cluvr-chat/src/main/java/com/example/chat/service/ChatService.java
@@ -1,4 +1,4 @@
 package com.example.chat.service;
 
-public class ChatService {
+public interface ChatService {
 }

--- a/cluvr-chat/src/main/java/com/example/chat/service/ChatService.java
+++ b/cluvr-chat/src/main/java/com/example/chat/service/ChatService.java
@@ -1,4 +1,24 @@
 package com.example.chat.service;
 
+import java.util.List;
+
+import com.example.chat.dto.request.ChatMessageRequestDto;
+import com.example.chat.dto.request.ChatRoomRequestDto;
+import com.example.chat.dto.request.CreateChatRoomRequestDto;
+import com.example.chat.dto.response.ChatRoomResponseDto;
+import com.example.chat.entity.ChatLog;
+import com.example.chat.entity.ChatRoomUser;
+
 public interface ChatService {
+	void createChatRoom(CreateChatRoomRequestDto request);
+
+	List<ChatRoomResponseDto> findChatRoomByClubAndRole(Long clubId, ChatRoomRequestDto request);
+
+	void saveMessage(ChatMessageRequestDto request);
+
+	List<ChatLog> getMessages(Long roomId);
+
+	void join(Long clubId, Long userId);
+
+	List<ChatRoomUser> getUserInRoom(Long roomId);
 }

--- a/cluvr-chat/src/main/java/com/example/chat/service/ChatService.java
+++ b/cluvr-chat/src/main/java/com/example/chat/service/ChatService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import com.example.chat.dto.request.ChatMessageRequestDto;
 import com.example.chat.dto.request.ChatRoomRequestDto;
 import com.example.chat.dto.request.CreateChatRoomRequestDto;
+import com.example.chat.dto.request.JoinRequestDto;
 import com.example.chat.dto.response.ChatRoomResponseDto;
 import com.example.chat.entity.ChatLog;
 import com.example.chat.entity.ChatRoomUser;
@@ -14,11 +15,15 @@ public interface ChatService {
 
 	List<ChatRoomResponseDto> findChatRoomByClubAndRole(Long clubId, ChatRoomRequestDto request);
 
+	void broadcastMessage(ChatMessageRequestDto request);
+
 	void saveMessage(ChatMessageRequestDto request);
 
 	List<ChatLog> getMessages(Long roomId);
 
-	void join(Long clubId, Long userId);
+	void join(Long clubId, JoinRequestDto userId);
+
+	void leave(Long clubId, Long userId);
 
 	List<ChatRoomUser> getUserInRoom(Long roomId);
 }

--- a/cluvr-chat/src/main/java/com/example/chat/service/ChatServiceImpl.java
+++ b/cluvr-chat/src/main/java/com/example/chat/service/ChatServiceImpl.java
@@ -4,18 +4,21 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.chat.dto.request.ChatMessageRequestDto;
 import com.example.chat.dto.request.ChatRoomRequestDto;
 import com.example.chat.dto.request.CreateChatRoomRequestDto;
+import com.example.chat.dto.request.JoinRequestDto;
 import com.example.chat.dto.response.ChatRoomResponseDto;
 import com.example.chat.dto.response.UserInfoResponseDto;
 import com.example.chat.entity.ChatLog;
 import com.example.chat.entity.ChatRoom;
 import com.example.chat.entity.ChatRoomUser;
 import com.example.chat.enums.ClubRole;
+import com.example.chat.enums.MessageType;
 import com.example.chat.enums.RoomType;
 import com.example.chat.repository.ChatLogRepository;
 import com.example.chat.repository.ChatRoomRepository;
@@ -29,7 +32,9 @@ public class ChatServiceImpl implements ChatService {
 	private final ChatRoomRepository chatRoomRepository;
 	private final ChatLogRepository chatLogRepository;
 	private final ChatRoomUserRepository userRepository;
-	private final GetInfoFromExternal getInfoFromExternal;
+	// private final GetInfoFromExternal getInfoFromExternal;
+	private final SimpMessagingTemplate messagingTemplate;
+	private final DummyInfoExternal dummyInfoExternal;
 
 	@Override
 	public void createChatRoom(CreateChatRoomRequestDto request) {
@@ -44,9 +49,20 @@ public class ChatServiceImpl implements ChatService {
 
 	@Override
 	public List<ChatRoomResponseDto> findChatRoomByClubAndRole(Long clubId, ChatRoomRequestDto request) {
-		List<ChatRoom> chatRooms;
+		// 역할 조회
+		UserInfoResponseDto userInfo = dummyInfoExternal.getUserInfo(request.getUserId());
+		ClubRole userRole = ClubRole.valueOf(userInfo.getRole().toUpperCase());
+		List<ChatRoomUser> users = userRepository.findByUserId(request.getUserId());
 
-		if (request.getRole() == ClubRole.MANAGER || request.getRole() == ClubRole.LEADER) {
+		for (ChatRoomUser u : users) {
+			if (u.getClubRole() != userRole) {
+				u.setClubRole(userRole);
+			}
+		}
+		userRepository.saveAll(users);
+
+		List<ChatRoom> chatRooms;
+		if (userRole == ClubRole.MANAGER || userRole == ClubRole.LEADER) {
 			chatRooms = chatRoomRepository.findByClubId(clubId);
 		} else {
 			chatRooms = chatRoomRepository.findByClubIdAndType(clubId, RoomType.MEMBER);
@@ -58,10 +74,25 @@ public class ChatServiceImpl implements ChatService {
 	}
 
 	@Override
+	@Transactional
+	public void broadcastMessage(ChatMessageRequestDto request) {
+		if (!userRepository.existsByRoomIdAndUserId(request.getRoomId(), request.getUserId()))
+			return;
+
+		ChatRoomUser user = userRepository.findByRoomIdAndUserId(request.getRoomId(), request.getUserId());
+		request.setNickname(user.getNickname());
+
+		String roomId = "/sub/chat/room/" + request.getRoomId();
+		messagingTemplate.convertAndSend(roomId, request); // 브로드 캐스트
+		saveMessage(request);
+	}
+
+	@Override
 	public void saveMessage(ChatMessageRequestDto request) {
 		ChatLog message = new ChatLog(
 			request.getRoomId(),
 			request.getUserId(),
+			request.getNickname(),
 			request.getMessage(),
 			request.getType(),
 			LocalDateTime.now()
@@ -76,23 +107,25 @@ public class ChatServiceImpl implements ChatService {
 
 	@Override
 	@Transactional
-	public void join(Long clubId, Long userId) {
+	public void join(Long clubId, JoinRequestDto request) {
 		List<ChatRoom> allRooms = chatRoomRepository.findByClubId(clubId);
+		Long userId = request.getUserId();
 
 		// 외부 API에서 닉네임, 역할 조회
-		UserInfoResponseDto userInfo = getInfoFromExternal.getUserInfo(userId);
-		String userRole = userInfo.getRole();
-		ClubRole clubRole = ClubRole.valueOf(userRole.toUpperCase());
+		// UserInfoResponseDto userInfo = getInfoFromExternal.getUserInfo(userId);
+		UserInfoResponseDto userInfo = dummyInfoExternal.getUserInfo(userId);
+		ClubRole userRole = ClubRole.valueOf(userInfo.getRole().toUpperCase());
 
 		List<ChatRoom> accessibleRooms = allRooms.stream()
 			.filter(room -> {
 				if (room.getType() == RoomType.MANAGER) {
-					return clubRole.equals("MANAGER") || clubRole.equals("LEADER");
+					// 룸 타입이 MANAGER인 경우 → 유저 롤이 MANAGER 또는 LEADER면 OK
+					return userRole == ClubRole.LEADER || userRole == ClubRole.MANAGER;
 				}
 				return true;
 			}).toList();
 
-		// 이미 가입한 방 제외
+		// 이미 가입한 방 제외하고 join 진행
 		for (ChatRoom room : accessibleRooms) {
 			boolean alreadyJoined = userRepository.existsByRoomIdAndUserId(room.getId(), userId);
 			if (!alreadyJoined) {
@@ -101,11 +134,47 @@ public class ChatServiceImpl implements ChatService {
 					room.getId(),
 					userId,
 					userInfo.getNickname(),
-					clubRole,
+					userRole,
 					LocalDateTime.now()
 				);
 				userRepository.save(join);
+				ChatMessageRequestDto enterMessage = ChatMessageRequestDto.from(MessageType.ENTER, room.getId(), userId,
+					userInfo.getNickname(),
+					userInfo.getNickname() + "님이 입장하셨습니다.");
+				broadcastMessage(enterMessage);
 			}
+		}
+
+		// 가입 후 채팅방 목록 불러오기
+		ChatRoomRequestDto chatRoomRequest = ChatRoomRequestDto.from(userId, userRole);
+		findChatRoomByClubAndRole(clubId, chatRoomRequest);
+	}
+
+	@Override
+	@Transactional
+	public void leave(Long clubId, Long userId) {
+		List<ChatRoom> allRooms = chatRoomRepository.findByClubId(clubId);
+
+		// 외부 API에서 닉네임, 역할 조회
+		// UserInfoResponseDto userInfo = getInfoFromExternal.getUserInfo(userId);
+		UserInfoResponseDto userInfo = dummyInfoExternal.getUserInfo(userId);
+		ClubRole userRole = ClubRole.valueOf(userInfo.getRole().toUpperCase());
+
+		List<ChatRoom> accessibleRooms = allRooms.stream()
+			.filter(room -> {
+				if (room.getType() == RoomType.MANAGER) {
+					return userRole == ClubRole.LEADER || userRole == ClubRole.MANAGER;
+				}
+				return true;
+			}).toList();
+
+		// 방 탈퇴 진행
+		for (ChatRoom room : accessibleRooms) {
+			userRepository.deleteByRoomIdAndUserId(room.getId(), userId);
+			ChatMessageRequestDto leaveMessage = ChatMessageRequestDto.from(MessageType.LEAVE, room.getId(), userId,
+				userInfo.getNickname(),
+				userInfo.getNickname() + "님이 퇴장하셨습니다.");
+			broadcastMessage(leaveMessage);
 		}
 	}
 
@@ -113,4 +182,5 @@ public class ChatServiceImpl implements ChatService {
 	public List<ChatRoomUser> getUserInRoom(Long roomId) {
 		return userRepository.findByRoomId(roomId);
 	}
+
 }

--- a/cluvr-chat/src/main/java/com/example/chat/service/ChatServiceImpl.java
+++ b/cluvr-chat/src/main/java/com/example/chat/service/ChatServiceImpl.java
@@ -47,6 +47,17 @@ public class ChatServiceImpl implements ChatService {
 		chatRoomRepository.save(room);
 	}
 
+	/**
+	 * 설명: 채팅방 리스트 조회
+	 * <p>
+	 * 클럽 Id와 유저의 클럽내에서의 Role 기반으로 채팅방 리스트를 가져옴
+	 * 외부 API 요청(도메인쪽으로)하여 Role 정보를 불러와서 갱신 해주고 불러옴
+	 *
+	 * @param clubId  : 채팅방 리스트가 속한 클럽 Id
+	 * @param request : 유저 Id와 유저의 클럽내에서의 role 정보
+	 * @return 채팅방 리스트 반환
+	 * @author Tcimel
+	 */
 	@Override
 	public List<ChatRoomResponseDto> findChatRoomByClubAndRole(Long clubId, ChatRoomRequestDto request) {
 		// 역할 조회

--- a/cluvr-chat/src/main/java/com/example/chat/service/ChatServiceImpl.java
+++ b/cluvr-chat/src/main/java/com/example/chat/service/ChatServiceImpl.java
@@ -1,0 +1,116 @@
+package com.example.chat.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.chat.dto.request.ChatMessageRequestDto;
+import com.example.chat.dto.request.ChatRoomRequestDto;
+import com.example.chat.dto.request.CreateChatRoomRequestDto;
+import com.example.chat.dto.response.ChatRoomResponseDto;
+import com.example.chat.dto.response.UserInfoResponseDto;
+import com.example.chat.entity.ChatLog;
+import com.example.chat.entity.ChatRoom;
+import com.example.chat.entity.ChatRoomUser;
+import com.example.chat.enums.ClubRole;
+import com.example.chat.enums.RoomType;
+import com.example.chat.repository.ChatLogRepository;
+import com.example.chat.repository.ChatRoomRepository;
+import com.example.chat.repository.ChatRoomUserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ChatServiceImpl implements ChatService {
+	private final ChatRoomRepository chatRoomRepository;
+	private final ChatLogRepository chatLogRepository;
+	private final ChatRoomUserRepository userRepository;
+	private final GetInfoFromExternal getInfoFromExternal;
+
+	@Override
+	public void createChatRoom(CreateChatRoomRequestDto request) {
+		ChatRoom room = new ChatRoom(
+			request.getClubId(),
+			request.getName(),
+			request.getUserId(),
+			request.getImageUrl(),
+			request.getType());
+		chatRoomRepository.save(room);
+	}
+
+	@Override
+	public List<ChatRoomResponseDto> findChatRoomByClubAndRole(Long clubId, ChatRoomRequestDto request) {
+		List<ChatRoom> chatRooms;
+
+		if (request.getRole() == ClubRole.MANAGER || request.getRole() == ClubRole.LEADER) {
+			chatRooms = chatRoomRepository.findByClubId(clubId);
+		} else {
+			chatRooms = chatRoomRepository.findByClubIdAndType(clubId, RoomType.MEMBER);
+		}
+
+		return chatRooms.stream()
+			.map(ChatRoomResponseDto::from)
+			.collect(Collectors.toList());
+	}
+
+	@Override
+	public void saveMessage(ChatMessageRequestDto request) {
+		ChatLog message = new ChatLog(
+			request.getRoomId(),
+			request.getUserId(),
+			request.getMessage(),
+			request.getType(),
+			LocalDateTime.now()
+		);
+		chatLogRepository.save(message);
+	}
+
+	@Override
+	public List<ChatLog> getMessages(Long roomId) {
+		return chatLogRepository.findByRoomIdOrderByCreatedAtAsc(roomId);
+	}
+
+	@Override
+	@Transactional
+	public void join(Long clubId, Long userId) {
+		List<ChatRoom> allRooms = chatRoomRepository.findByClubId(clubId);
+
+		// 외부 API에서 닉네임, 역할 조회
+		UserInfoResponseDto userInfo = getInfoFromExternal.getUserInfo(userId);
+		String userRole = userInfo.getRole();
+		ClubRole clubRole = ClubRole.valueOf(userRole.toUpperCase());
+
+		List<ChatRoom> accessibleRooms = allRooms.stream()
+			.filter(room -> {
+				if (room.getType() == RoomType.MANAGER) {
+					return clubRole.equals("MANAGER") || clubRole.equals("LEADER");
+				}
+				return true;
+			}).toList();
+
+		// 이미 가입한 방 제외
+		for (ChatRoom room : accessibleRooms) {
+			boolean alreadyJoined = userRepository.existsByRoomIdAndUserId(room.getId(), userId);
+			if (!alreadyJoined) {
+				ChatRoomUser join = new ChatRoomUser(
+					clubId,
+					room.getId(),
+					userId,
+					userInfo.getNickname(),
+					clubRole,
+					LocalDateTime.now()
+				);
+				userRepository.save(join);
+			}
+		}
+	}
+
+	@Override
+	public List<ChatRoomUser> getUserInRoom(Long roomId) {
+		return userRepository.findByRoomId(roomId);
+	}
+}

--- a/cluvr-chat/src/main/java/com/example/chat/service/DummyInfoExternal.java
+++ b/cluvr-chat/src/main/java/com/example/chat/service/DummyInfoExternal.java
@@ -1,0 +1,13 @@
+package com.example.chat.service;
+
+import org.springframework.stereotype.Component;
+
+import com.example.chat.dto.response.UserInfoResponseDto;
+
+@Component
+public class DummyInfoExternal implements GetInfoFromExternal {
+	@Override
+	public UserInfoResponseDto getUserInfo(Long userId) {
+		return new UserInfoResponseDto(userId, "테스트 유저" + userId, "MEMBER", "http://example.com/profile.png");
+	}
+}

--- a/cluvr-chat/src/main/java/com/example/chat/service/DummyInfoExternal.java
+++ b/cluvr-chat/src/main/java/com/example/chat/service/DummyInfoExternal.java
@@ -8,6 +8,6 @@ import com.example.chat.dto.response.UserInfoResponseDto;
 public class DummyInfoExternal implements GetInfoFromExternal {
 	@Override
 	public UserInfoResponseDto getUserInfo(Long userId) {
-		return new UserInfoResponseDto(userId, "테스트 유저" + userId, "MEMBER", "http://example.com/profile.png");
+		return new UserInfoResponseDto(userId, "테스트 유저" + userId, "LEADER", "http://example.com/profile.png");
 	}
 }

--- a/cluvr-chat/src/main/java/com/example/chat/service/GetInfoFromExternal.java
+++ b/cluvr-chat/src/main/java/com/example/chat/service/GetInfoFromExternal.java
@@ -1,0 +1,7 @@
+package com.example.chat.service;
+
+import com.example.chat.dto.response.UserInfoResponseDto;
+
+public interface GetInfoFromExternal {
+	UserInfoResponseDto getUserInfo(Long userId);
+}

--- a/cluvr-chat/src/main/java/com/example/chat/service/GetInfoFromExternalImpl.java
+++ b/cluvr-chat/src/main/java/com/example/chat/service/GetInfoFromExternalImpl.java
@@ -1,5 +1,6 @@
 package com.example.chat.service;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
@@ -11,6 +12,7 @@ import com.example.global.response.response.BaseResponse;
 
 import lombok.RequiredArgsConstructor;
 
+@Profile("!test")
 @Component
 @RequiredArgsConstructor
 public class GetInfoFromExternalImpl implements GetInfoFromExternal {

--- a/cluvr-chat/src/main/java/com/example/chat/service/GetInfoFromExternalImpl.java
+++ b/cluvr-chat/src/main/java/com/example/chat/service/GetInfoFromExternalImpl.java
@@ -1,0 +1,32 @@
+package com.example.chat.service;
+
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import com.example.chat.dto.response.UserInfoResponseDto;
+import com.example.global.response.response.BaseResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class GetInfoFromExternalImpl implements GetInfoFromExternal {
+	private final RestTemplate restTemplate;
+
+	// 유저별 가입한 클럽 리스트랑, 해당 클럽 리스트에서의 role정보
+	@Override
+	public UserInfoResponseDto getUserInfo(Long userId) {
+		String url = "http://localhost:8080/api/users/" + userId;
+		ResponseEntity<BaseResponse<UserInfoResponseDto>> response = restTemplate.exchange(
+			url,
+			HttpMethod.GET,
+			null,
+			new ParameterizedTypeReference<>() {
+			}
+		);
+		return response.getBody().getData();
+	}
+}

--- a/cluvr-chat/src/main/resources/static/index.html
+++ b/cluvr-chat/src/main/resources/static/index.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Cluvr 채팅방</title>
+    <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
+    <style>
+        body {
+            font-family: sans-serif;
+            max-width: 500px;
+            margin: 0 auto;
+            padding: 1rem;
+        }
+
+        #chatArea {
+            border: 1px solid #ccc;
+            height: 300px;
+            overflow-y: auto;
+            padding: 0.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .chat {
+            margin-bottom: 0.5rem;
+        }
+
+        .me {
+            text-align: right;
+            color: blue;
+        }
+
+        .other {
+            text-align: left;
+            color: black;
+        }
+    </style>
+</head>
+<body>
+<h2>💬 Cluvr 채팅방</h2>
+<label>Room ID: <input type="text" id="roomId" value="1"/></label><br/>
+<label>내 ID: <input type="text" id="userId" value="1001"/></label><br/>
+<button onclick="connect()">🔌 접속 & 구독</button>
+
+<div id="chatArea"></div>
+
+<input type="text" id="messageInput" placeholder="메시지를 입력하세요" style="width: 80%;"/>
+<button onclick="sendMessage()">📤 보내기</button>
+
+<script>
+    let stompClient = null;
+    let userId = null;
+
+    function connect() {
+        const socket = new SockJS("http://localhost:8082/cluvr-chat");
+        stompClient = Stomp.over(socket);
+
+        const roomId = document.getElementById("roomId").value;
+        userId = document.getElementById("userId").value;
+
+        stompClient.connect({}, () => {
+            console.log("✅ STOMP 연결 성공");
+            stompClient.subscribe(`/sub/chat/room/${roomId}`, (msg) => {
+                const chat = JSON.parse(msg.body);
+                const area = document.getElementById("chatArea");
+                const chatClass = (parseInt(chat.userId) === parseInt(userId)) ? "me" : "other";
+                const content = `<div class="chat ${chatClass}"><b>${chat.userId}:</b> ${chat.message}</div>`;
+                area.innerHTML += content;
+                area.scrollTop = area.scrollHeight;
+            });
+
+            alert(`방 ${roomId}에 접속했습니다`);
+        });
+    }
+
+    function sendMessage() {
+        const roomId = document.getElementById("roomId").value;
+        const message = document.getElementById("messageInput").value;
+
+        const payload = {
+            roomId: parseInt(roomId),
+            userId: parseInt(userId),
+            message: message,
+            type: "TALK"
+        };
+
+        stompClient.send("/chat/message", {}, JSON.stringify(payload));
+        document.getElementById("messageInput").value = "";
+    }
+</script>
+</body>
+</html>

--- a/cluvr-chat/src/main/resources/static/index.html
+++ b/cluvr-chat/src/main/resources/static/index.html
@@ -8,17 +8,18 @@
     <style>
         body {
             font-family: sans-serif;
-            max-width: 500px;
-            margin: 0 auto;
+            max-width: 700px;
+            margin: auto;
             padding: 1rem;
         }
 
-        #chatArea {
+        #chatBox {
             border: 1px solid #ccc;
             height: 300px;
             overflow-y: auto;
-            padding: 0.5rem;
             margin-bottom: 1rem;
+            padding: 0.5rem;
+            background: #f9f9f9;
         }
 
         .chat {
@@ -34,59 +35,195 @@
             text-align: left;
             color: black;
         }
+
+        .system {
+            text-align: center;
+            color: gray;
+            font-style: italic;
+        }
     </style>
 </head>
 <body>
 <h2>💬 Cluvr 채팅방</h2>
-<label>Room ID: <input type="text" id="roomId" value="1"/></label><br/>
-<label>내 ID: <input type="text" id="userId" value="1001"/></label><br/>
-<button onclick="connect()">🔌 접속 & 구독</button>
 
-<div id="chatArea"></div>
+<!-- 사용자 정보 입력 -->
+<label>클럽 ID: <input type="number" id="clubId" value="1"></label><br/>
+<label>내 ID: <input type="number" id="userId" value="1001"></label><br/>
+<button onclick="fetchChatRooms()">📜 채팅방 불러오기</button>
 
-<input type="text" id="messageInput" placeholder="메시지를 입력하세요" style="width: 80%;"/>
-<button onclick="sendMessage()">📤 보내기</button>
+<!-- 채팅방 목록 -->
+<div id="chatRoomList"></div>
 
+<!-- 채팅방 생성 -->
+<hr>
+<h3>📁 채팅방 생성</h3>
+<label>방 이름: <input type="text" id="roomName"></label><br/>
+<label>이미지 URL: <input type="text" id="imageUrl"></label><br/>
+<label>방 타입(MANAGER / MEMBER): <input type="text" id="roomType" value="MEMBER"></label><br/>
+<button onclick="createChatRoom()">➕ 채팅방 생성</button>
+
+<!-- 채팅창 -->
+<hr>
+<h3>💬 채팅</h3>
+<div id="chatBox"></div>
+<input type="text" id="messageInput" placeholder="메시지를 입력하세요" style="width: 80%;">
 <script>
-    let stompClient = null;
+    let currentRoomId = null;
+    let clubId = null;
     let userId = null;
+    let stompClient = null;
+    let socket = null;
+    let currentSubscription = null;
 
-    function connect() {
-        const socket = new SockJS("http://localhost:8082/cluvr-chat");
-        stompClient = Stomp.over(socket);
-
-        const roomId = document.getElementById("roomId").value;
-        userId = document.getElementById("userId").value;
-
-        stompClient.connect({}, () => {
-            console.log("✅ STOMP 연결 성공");
-            stompClient.subscribe(`/sub/chat/room/${roomId}`, (msg) => {
-                const chat = JSON.parse(msg.body);
-                const area = document.getElementById("chatArea");
-                const chatClass = (parseInt(chat.userId) === parseInt(userId)) ? "me" : "other";
-                const content = `<div class="chat ${chatClass}"><b>${chat.userId}:</b> ${chat.message}</div>`;
-                area.innerHTML += content;
-                area.scrollTop = area.scrollHeight;
-            });
-
-            alert(`방 ${roomId}에 접속했습니다`);
+    function joinChatRoom(clubId, userId) {
+        return fetch(`http://localhost:8082/club/${clubId}/chat/room/join`, {
+            method: "POST",
+            headers: {"Content-Type": "application/json"},
+            body: JSON.stringify(userId)
         });
     }
 
+    document.getElementById("messageInput").addEventListener("keydown", function (event) {
+        if (event.key === "Enter") {
+            sendMessage();
+        }
+    });
+
+    function connectSocketAndSubscribe(roomId) {
+        clubId = parseInt(document.getElementById("clubId").value);
+        userId = parseInt(document.getElementById("userId").value);
+
+        // 이전 구독 해제
+        if (currentSubscription) {
+            currentSubscription.unsubscribe();
+        }
+
+        // 채팅창 비우기
+        const chatBox = document.getElementById("chatBox");
+        chatBox.innerHTML = "";
+
+        // 연결 상태에 따라 소켓 연결 관리
+        if (stompClient && stompClient.connected) {
+            stompClient.disconnect(() => {
+                console.log("Disconnected previous STOMP connection.");
+                startNewConnection();
+            });
+        } else {
+            startNewConnection();
+        }
+
+        // Helper function for connection & subscription
+        function startNewConnection() {
+            socket = new SockJS("http://localhost:8082/cluvr-chat");
+            stompClient = Stomp.over(socket);
+            stompClient.connect({}, () => {
+                joinChatRoom(clubId, userId).then(() => {
+                    currentRoomId = roomId;
+
+                    currentSubscription = stompClient.subscribe(`/sub/chat/room/${roomId}`, function (message) {
+                        const msgObj = JSON.parse(message.body);
+                        renderMessage(msgObj);
+                    });
+
+                    fetch(`http://localhost:8082/club/${clubId}/chat/${roomId}`)
+                        .then(res => res.json())
+                        .then(data => {
+                            const chatBox = document.getElementById("chatBox");
+                            chatBox.innerHTML = "";
+                            if (data.data && Array.isArray(data.data)) {
+                                data.data.forEach(renderMessage);
+                            }
+                        });
+                });
+            });
+        }
+    }
+
+    function renderMessage(message) {
+        const chatBox = document.getElementById("chatBox");
+        const msgDiv = document.createElement("div");
+
+        if (message.type === "ENTER" || message.type === "LEAVE") {
+            msgDiv.className = "system";
+            msgDiv.textContent = message.message;
+        } else {
+            msgDiv.className = parseInt(message.userId) === parseInt(userId) ? "me" : "other";
+            msgDiv.textContent = `${message.nickname} : ${message.message}`;
+        }
+
+        chatBox.appendChild(msgDiv);
+        chatBox.scrollTop = chatBox.scrollHeight;
+    }
+
+    function fetchChatRooms() {
+        const clubId = parseInt(document.getElementById("clubId").value);
+        userId = parseInt(document.getElementById("userId").value);
+        // nickname = document.getElementById("nickname").value;
+        // const role = document.getElementById("role").value;
+
+        fetch(`http://localhost:8082/club/${clubId}/chat/list`, {
+            method: "POST",
+            headers: {"Content-Type": "application/json"},
+            body: JSON.stringify({userId})
+        })
+            .then(res => res.json())
+            .then(data => {
+                const roomListDiv = document.getElementById("chatRoomList");
+                roomListDiv.innerHTML = "<h3>📦 채팅방 리스트</h3>";
+                if (data.data && Array.isArray(data.data)) {
+                    data.data.forEach(room => {
+                        const btn = document.createElement("button");
+                        btn.textContent = room.name + ` (${room.type})`;
+                        btn.onclick = () => {
+                            currentRoomId = room.id;
+                            connectSocketAndSubscribe(currentRoomId);
+                        };
+                        roomListDiv.appendChild(btn);
+                        roomListDiv.appendChild(document.createElement("br"));
+                    });
+                }
+            });
+    }
+
+    function createChatRoom() {
+        const clubId = parseInt(document.getElementById("clubId").value);
+        const name = document.getElementById("roomName").value;
+        const imageUrl = document.getElementById("imageUrl").value;
+        const type = document.getElementById("roomType").value;
+        const userId = parseInt(document.getElementById("userId").value);
+
+        fetch("http://localhost:8082/chat/create", {
+            method: "POST",
+            headers: {"Content-Type": "application/json"},
+            body: JSON.stringify({
+                clubId,
+                name,
+                userId,
+                imageUrl,
+                type
+            })
+        })
+            .then(res => res.json())
+            .then(() => {
+                alert("채팅방이 생성되었습니다.");
+                fetchChatRooms();
+            });
+    }
+
     function sendMessage() {
-        const roomId = document.getElementById("roomId").value;
         const message = document.getElementById("messageInput").value;
+        if (!message || !currentRoomId || !stompClient || !stompClient.connected) return;
 
         const payload = {
-            roomId: parseInt(roomId),
+            roomId: currentRoomId,
             userId: parseInt(userId),
             message: message,
             type: "TALK"
         };
-
         stompClient.send("/chat/message", {}, JSON.stringify(payload));
         document.getElementById("messageInput").value = "";
     }
 </script>
+<button onclick="sendMessage()">📤 보내기</button>
 </body>
 </html>

--- a/cluvr-chat/src/test.http
+++ b/cluvr-chat/src/test.http
@@ -20,7 +20,7 @@ POST http://localhost:8082/club/1/chat/list
 Content-Type: application/json
 
 {
-  "userId": 1001,
+  "userId": 1003,
   "role": "LEADER"
 }
 
@@ -32,5 +32,5 @@ POST localhost:8082/club/1/chat/join
 Content-Type: application/json
 
 {
-  "userId": 1001
+  "userId": 1003
 }

--- a/cluvr-chat/src/test.http
+++ b/cluvr-chat/src/test.http
@@ -1,0 +1,36 @@
+### GET request to example server
+GET https://examples.http-client.intellij.net/get
+    ?generated-in=IntelliJ IDEA
+
+### 채팅방 생성
+POST http://localhost:8082/chat/create
+Content-Type: application/json
+
+{
+  "clubId": 1,
+  "type": "MANAGER",
+  "userId": 1001,
+  "imageUrl": "test",
+  "name": "방 1",
+  "role": "LEADER"
+}
+
+### 채팅방 조회
+POST http://localhost:8082/club/1/chat/list
+Content-Type: application/json
+
+{
+  "userId": 1001,
+  "role": "LEADER"
+}
+
+### 채팅방 대화 조회
+GET localhost:8082/club/1/chat/1
+
+### 채팅방 조인
+POST localhost:8082/club/1/chat/join
+Content-Type: application/json
+
+{
+  "userId": 1001
+}


### PR DESCRIPTION
<!-- 
꼭 제목을 아래와 같은 형식으로 변경해주세요 !
Feat/#24:board-crud

: <- 이거 잊으시면 안 됩니다!
-->

## 📌 개요

<!-- 어떤 작업을 했는지 한 줄로 요약해주세요. -->

클럽 기반 채팅 기능을 제공하는 실시간 메시징 서버
Spring Boot + WebSocket(STOMP) 기반으로 구성되어 있으며, 클라이언트는 SockJS를 통해 채팅 서버에 접속한다.

---

## ✅ 작업 내용

<!-- 상세 작업 내용을 bullet 형식으로 정리해주세요. -->

### 🥕 채팅방 생성 (createChatRoom)
- 클럽 ID, 생성자 ID, 채팅방 이름, 유형(MEMBER/MANAGER), 이미지 정보를 받아 채팅방을 생성함.
- MySQL의 chat_room 테이블에 저장됨.

### 🥕 채팅방 목록 조회 (findChatRoomByClubAndRole)
- 클럽 내에서 유저의 역할(LEADER/MANAGER/MEMBER)에 따라 조회 가능 채팅방이 달라짐.
- MANAGER, LEADER는 모든 방 접근 가능
- MEMBER는 RoomType.MEMBER만 조회 가능
- 외부 API(dummyInfoExternal)를 통해 유저 역할 갱신

### 🥕 채팅방 입장/퇴장 (join, leave) - 퇴장은 아직 미구현
- 입장 시:
  - 유저는 접근 가능한 모든 채팅방에 자동 가입
  - 시스템 메시지로 입장 알림을 채팅방에 브로드캐스트
- 퇴장 시:
  - 모든 참여 중인 채팅방에서 탈퇴
  - 시스템 메시지로 퇴장 알림 전송

### 🥕 메시지 전송 (broadcastMessage)
- 메시지 전송 시:
  - WebSocket을 통해 /sub/chat/room/{roomId} 채널로 브로드캐스트
  - 동시에 MongoDB에 메시지 저장

### 🥕 채팅 로그 조회 (getMessages)
  - MongoDB에서 특정 방 ID 기준으로 과거 메시지 조회
  - createdAt 기준 오름차순 정렬

### 🥕 WebSocket 구성
- 엔드포인트: /cluvr-chat
- 클라이언트는 SockJS로 접속 가능
- 메시지 라우팅 설정:
  - pub: /chat/**
  - sub: /sub/** (예: /sub/chat/room/1)

### 🥕 WebConfig : CORS 설정
프론트엔드는 브라우저에서 localhost:63342 포트로 실행되며, CORS 이슈를 피하기 위한 설정이 포함됨.
```
registry.addMapping("/**")
    .allowedOrigins("http://localhost:63342")
    .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
    .allowCredentials(true);
```
---

## 💬 기타 참고 사항
- Kafka/Redis 연동
  - 현재는 SimpMessagingTemplate을 통한 브로드캐스트 사용 중
  - 추후 Redis Pub/Sub 또는 Kafka 연동 시 외부 브로커 설정 및 수신 처리 로직 필요
- 외부 인증 연동
  - 현재는 dummyInfoExternal로 외부 API 요청을 모사함
  - 실서비스에서는 RestTemplate 또는 WebClient를 통해 인증 서버와 통신 예정
