### PR TITLE
Feat/#93:TIL, 공지사항 멤버 권한 검증 추가

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-template.md
+++ b/.github/ISSUE_TEMPLATE/bug-template.md
@@ -2,7 +2,7 @@
 name: Bug Template
 about: 버그 이슈 템플릿
 title: 'Bug:'
-labels: bug
+labels: 🐞 Bug 🐞
 assignees: alpomjeong, dnjs5024, escomputer, sinyoung0403, Tcimel, YongLeeCode
 
 ---
@@ -14,17 +14,21 @@ ex:"Bud:Redis설정 에러 발생"
 --->
 
 ## 🐞 버그 설명
+
 무슨 문제가 발생했는지 명확하고 간단하게 설명해주세요.
 
 ## 🔁 재현 방법
+
 문제를 재현하는 단계:
+
 1. ...
 2. ...
 3. ...
 
 ## 📸 스크린샷 (선택사항)
+
 문제를 보여주는 스크린샷이 있다면 첨부해주세요.
 
-
 ## 📎 추가 정보
+
 해당 문제와 관련된 다른 정보가 있다면 자유롭게 작성해주세요.

--- a/.github/ISSUE_TEMPLATE/build-template.md
+++ b/.github/ISSUE_TEMPLATE/build-template.md
@@ -2,7 +2,7 @@
 name: Build Template
 about: 빌드 이슈 템플릿
 title: 'Build:'
-labels: build
+labels: 🛠️ Build 🛠️
 assignees: alpomjeong, dnjs5024, escomputer, sinyoung0403, Tcimel, YongLeeCode
 
 ---
@@ -14,7 +14,9 @@ ex:"Build:CI/CD 파이프라인 추가"
 --->
 
 ## ⚙️ 설정한 내용
+
 예: Gradle 설정, GitHub Actions, Dockerfile 등
 
 ## 📋 상세 내용
+
 문제 설명 혹은 개선하고 싶은 내용 작성

--- a/.github/ISSUE_TEMPLATE/docs-template.md
+++ b/.github/ISSUE_TEMPLATE/docs-template.md
@@ -2,7 +2,7 @@
 name: Docs Template
 about: 문서 이슈 템플릿
 title: 'Docs:'
-labels: documentation
+labels: 📝 Documentation 📝
 assignees: alpomjeong, dnjs5024, escomputer, sinyoung0403, Tcimel, YongLeeCode
 
 ---
@@ -14,10 +14,13 @@ ex:"Document:클럽 관련 주석 추가"
 --->
 
 ## 📑 문서 대상
+
 어떤 문서를 작성하거나 수정할 건가요?
 
 ## ✍️ 변경 내용
+
 어떤 내용을 추가하거나 변경할 건지 설명해주세요
 
 ## 📎 참고 링크
+
 관련 이슈, 레퍼런스가 있다면 남겨주세요

--- a/.github/ISSUE_TEMPLATE/feature-template.md
+++ b/.github/ISSUE_TEMPLATE/feature-template.md
@@ -2,7 +2,7 @@
 name: Feature Template
 about: 기능 이슈 템플릿
 title: 'Feat:'
-labels: enhancement
+labels: ✨ Feature ✨
 assignees: alpomjeong, dnjs5024, escomputer, sinyoung0403, Tcimel, YongLeeCode
 
 ---
@@ -14,12 +14,12 @@ ex:"Feat:Club Entity 다건 조회기능 추가"
 --->
 
 ## ✨ 요청하는 기능 설명
+
 어떤 기능이 필요하고, 왜 필요한지 간단하게 설명해주세요.
 
-
 ## 🎉 기대 효과
-이 기능이 도입되었을 때 어떤 이점이 있는지 작성해주세요.
 
+이 기능이 도입되었을 때 어떤 이점이 있는지 작성해주세요.
 
 ## 📝 작업 항목
 
@@ -27,4 +27,5 @@ ex:"Feat:Club Entity 다건 조회기능 추가"
 - [ ] 작업 2
 
 ## 📎기타 참고사항
+
 관련 이슈, 레퍼런스 링크, 주의할 점 등

--- a/.github/ISSUE_TEMPLATE/refactor-template.md
+++ b/.github/ISSUE_TEMPLATE/refactor-template.md
@@ -2,7 +2,7 @@
 name: Refactor Template
 about: 리팩토링 이슈 템플릿
 title: 'Refactor:'
-labels: Refactor
+labels: ♻️ Refactor ♻️
 assignees: alpomjeong, dnjs5024, escomputer, sinyoung0403, Tcimel, YongLeeCode
 
 ---
@@ -14,10 +14,13 @@ ex:"Refactor:인스턴스화 방식을 정적팩토링으로 리팩토링"
 --->
 
 ## 🔨 리팩토링 대상
+
 어떤 코드나 모듈을 리팩토링할 계획인가요?
 
 ## 💡 리팩토링 이유
+
 리팩토링이 필요한 이유를 적어주세요 (가독성, 중복 제거, 성능 개선 등)
 
 ## 📝 추가 정보
+
 참고할 내용이나 고민이 있다면 적어주세요.

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/controller/ProblemFormController.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/controller/ProblemFormController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -45,7 +46,8 @@ public class ProblemFormController {
 			clubId,
 			problemFormRequestDto
 		);
-		return ResponseEntity.ok(BaseResponse.success(problemFormResponseDto, ResponseCode.CREATED));
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(BaseResponse.success(problemFormResponseDto, ResponseCode.CREATED));
 	}
 
 	@GetMapping("/{problemFormId}")

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/controller/ProblemFormController.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/controller/ProblemFormController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.cluvrapi.domain.applicationForm.dto.request.CreateProblemFormRequestDto;
@@ -68,6 +69,15 @@ public class ProblemFormController {
 		return ResponseEntity.ok(BaseResponse.success(pageProblemFormResponseDto, ResponseCode.OK));
 	}
 
+	@GetMapping("/active")
+	public ResponseEntity<BaseResponse<InfoProblemFormResponseDto>> findActiveProblemFormByClubId(
+		@PathVariable Long clubId
+	) {
+		InfoProblemFormResponseDto problemFormResponseDto = problemFormService.findActiveProblemFormByClubId(
+			clubId);
+		return ResponseEntity.ok(BaseResponse.success(problemFormResponseDto, ResponseCode.OK));
+	}
+
 	@PatchMapping("/{problemFormId}")
 	public ResponseEntity<BaseResponse<Void>> updateProblemForm(
 		@Auth AuthUser authUser,
@@ -85,10 +95,18 @@ public class ProblemFormController {
 		@PathVariable Long clubId,
 		@PathVariable Long problemFormId
 	) {
-		problemFormService.deleteProblem(clubId, problemFormId);
 		problemFormService.deleteProblem(authUser.id(), clubId, problemFormId);
 		return ResponseEntity.ok(BaseResponse.success(ResponseCode.NO_CONTENT));
 	}
+
+	@PatchMapping("/{problemFormId}/activation")
+	public ResponseEntity<BaseResponse<Void>> changeActivationState(
+		@Auth AuthUser authUser,
+		@PathVariable Long clubId,
+		@PathVariable Long problemFormId,
+		@RequestParam Boolean active
+	) {
+		problemFormService.changeActivationState(authUser.id(), clubId, problemFormId, active);
 		return ResponseEntity.ok(BaseResponse.success(ResponseCode.NO_CONTENT));
 	}
 }

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/controller/ProblemFormController.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/controller/ProblemFormController.java
@@ -21,6 +21,8 @@ import com.example.cluvrapi.domain.applicationForm.dto.request.UpdateProblemForm
 import com.example.cluvrapi.domain.applicationForm.dto.response.CreateProblemFormResponseDto;
 import com.example.cluvrapi.domain.applicationForm.dto.response.InfoProblemFormResponseDto;
 import com.example.cluvrapi.domain.applicationForm.service.ProblemFormService;
+import com.example.cluvrapi.domain.common.annotation.Auth;
+import com.example.cluvrapi.domain.common.dto.AuthUser;
 import com.example.cluvrapi.domain.common.dto.PageResponseDto;
 import com.example.cluvrapi.global.response.BaseResponse;
 import com.example.cluvrapi.global.response.ResponseCode;
@@ -33,11 +35,15 @@ public class ProblemFormController {
 
 	@PostMapping
 	public ResponseEntity<BaseResponse<CreateProblemFormResponseDto>> createProblemForm(
+		@Auth AuthUser authUser,
 		@PathVariable Long clubId,
 		@Valid @RequestBody CreateProblemFormRequestDto problemFormRequestDto
 	) {
-		CreateProblemFormResponseDto problemFormResponseDto = problemFormService.createProblemForm(clubId,
-			problemFormRequestDto);
+		CreateProblemFormResponseDto problemFormResponseDto = problemFormService.createProblemForm(
+			authUser.id(),
+			clubId,
+			problemFormRequestDto
+		);
 		return ResponseEntity.ok(BaseResponse.success(problemFormResponseDto, ResponseCode.CREATED));
 	}
 
@@ -64,20 +70,25 @@ public class ProblemFormController {
 
 	@PatchMapping("/{problemFormId}")
 	public ResponseEntity<BaseResponse<Void>> updateProblemForm(
+		@Auth AuthUser authUser,
 		@PathVariable Long clubId,
 		@PathVariable Long problemFormId,
 		@Valid @RequestBody UpdateProblemFormRequestDto updateProblemFormRequestDto
 	) {
-		problemFormService.updateProblemForm(clubId, problemFormId, updateProblemFormRequestDto);
+		problemFormService.updateProblemForm(authUser.id(), clubId, problemFormId, updateProblemFormRequestDto);
 		return ResponseEntity.ok(BaseResponse.success(ResponseCode.NO_CONTENT));
 	}
 
 	@DeleteMapping("/{problemFormId}")
 	public ResponseEntity<BaseResponse<Void>> deleteProblemForm(
+		@Auth AuthUser authUser,
 		@PathVariable Long clubId,
 		@PathVariable Long problemFormId
 	) {
 		problemFormService.deleteProblem(clubId, problemFormId);
+		problemFormService.deleteProblem(authUser.id(), clubId, problemFormId);
+		return ResponseEntity.ok(BaseResponse.success(ResponseCode.NO_CONTENT));
+	}
 		return ResponseEntity.ok(BaseResponse.success(ResponseCode.NO_CONTENT));
 	}
 }

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/controller/SubmissionFormController.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/controller/SubmissionFormController.java
@@ -21,6 +21,8 @@ import com.example.cluvrapi.domain.applicationForm.dto.request.UpdateSubmissionT
 import com.example.cluvrapi.domain.applicationForm.dto.response.CreateSubmissionFormResponseDto;
 import com.example.cluvrapi.domain.applicationForm.dto.response.InfoSubmissionFormResponseDto;
 import com.example.cluvrapi.domain.applicationForm.service.SubmissionFormService;
+import com.example.cluvrapi.domain.common.annotation.Auth;
+import com.example.cluvrapi.domain.common.dto.AuthUser;
 import com.example.cluvrapi.domain.common.dto.PageResponseDto;
 import com.example.cluvrapi.global.response.BaseResponse;
 import com.example.cluvrapi.global.response.ResponseCode;
@@ -34,11 +36,15 @@ public class SubmissionFormController {
 
 	@PostMapping
 	public ResponseEntity<BaseResponse<CreateSubmissionFormResponseDto>> createSubmissionForm(
+		@Auth AuthUser authUser,
 		@PathVariable Long clubId,
 		@Valid @RequestBody CreateSubmissionFormRequestDto submissionFormRequestDto
 	) {
-		CreateSubmissionFormResponseDto submissionFormResponseDto = submissionFormService.createSubmissionForm(clubId,
-			submissionFormRequestDto);
+		CreateSubmissionFormResponseDto submissionFormResponseDto = submissionFormService.createSubmissionForm(
+			authUser.id(),
+			clubId,
+			submissionFormRequestDto
+		);
 		return ResponseEntity.ok(BaseResponse.success(submissionFormResponseDto, ResponseCode.CREATED));
 	}
 
@@ -65,20 +71,23 @@ public class SubmissionFormController {
 
 	@PatchMapping("/{submissionFormId}")
 	public ResponseEntity<BaseResponse<Void>> updateSubmissionForm(
+		@Auth AuthUser authUser,
 		@PathVariable Long clubId,
 		@PathVariable Long submissionFormId,
 		@Valid @RequestBody UpdateSubmissionTemplateRequestDto submissionTemplateRequestDto
 	) {
-		submissionFormService.updateSubmissionTemplate(clubId, submissionFormId, submissionTemplateRequestDto);
+		submissionFormService.updateSubmissionTemplate(authUser.id(), clubId, submissionFormId,
+			submissionTemplateRequestDto);
 		return ResponseEntity.ok(BaseResponse.success(ResponseCode.NO_CONTENT));
 	}
 
 	@DeleteMapping("/{submissionFormId}")
 	public ResponseEntity<BaseResponse<Void>> deleteSubmissionForm(
+		@Auth AuthUser authUser,
 		@PathVariable Long clubId,
 		@PathVariable Long submissionFormId
 	) {
-		submissionFormService.deleteSubmissionForm(clubId, submissionFormId);
+		submissionFormService.deleteSubmissionForm(authUser.id(), clubId, submissionFormId);
 		return ResponseEntity.ok(BaseResponse.success(ResponseCode.NO_CONTENT));
 	}
 }

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/dto/response/InfoProblemFormResponseDto.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/dto/response/InfoProblemFormResponseDto.java
@@ -2,10 +2,13 @@ package com.example.cluvrapi.domain.applicationForm.dto.response;
 
 import lombok.Getter;
 
+import com.example.cluvrapi.domain.applicationForm.entity.ProblemForm;
 import com.querydsl.core.annotations.QueryProjection;
 
 @Getter
 public class InfoProblemFormResponseDto {
+
+	private Long problemFormId;
 
 	private String problemTemplate;
 
@@ -13,11 +16,29 @@ public class InfoProblemFormResponseDto {
 
 	private String gradingCriteria;
 
+	private Boolean isActive;
+
 	@QueryProjection
-	public InfoProblemFormResponseDto(String problemTemplate, String submissionInstructions,
-		String gradingCriteria) {
+	public InfoProblemFormResponseDto(
+		Long problemFormId,
+		String problemTemplate,
+		String submissionInstructions,
+		String gradingCriteria,
+		Boolean isActive) {
+		this.problemFormId = problemFormId;
 		this.problemTemplate = problemTemplate;
 		this.submissionInstructions = submissionInstructions;
 		this.gradingCriteria = gradingCriteria;
+		this.isActive = isActive;
+	}
+
+	public static InfoProblemFormResponseDto from(ProblemForm problemForm) {
+		return new InfoProblemFormResponseDto(
+			problemForm.getId(),
+			problemForm.getProblemTemplate(),
+			problemForm.getSubmissionInstructions(),
+			problemForm.getGradingCriteria(),
+			problemForm.getIsActive()
+		);
 	}
 }

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/entity/ProblemForm.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/entity/ProblemForm.java
@@ -70,10 +70,12 @@ public class ProblemForm extends BaseTimeEntity {
 	/**
 	 * 생성자 메서드
 	 */
-	public ProblemForm(String problemTemplate, String submissionInstructions, String gradingCriteria, Club club) {
+	public ProblemForm(String problemTemplate, String submissionInstructions, String gradingCriteria, Boolean isActive,
+		Club club) {
 		this.problemTemplate = problemTemplate;
 		this.submissionInstructions = submissionInstructions;
 		this.gradingCriteria = gradingCriteria;
+		this.isActive = isActive;
 		this.club = club;
 	}
 

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/entity/ProblemForm.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/entity/ProblemForm.java
@@ -75,7 +75,7 @@ public class ProblemForm extends BaseTimeEntity {
 		this.problemTemplate = problemTemplate;
 		this.submissionInstructions = submissionInstructions;
 		this.gradingCriteria = gradingCriteria;
-		this.isActive = isActive;
+		this.isActive = Boolean.TRUE.equals(isActive);
 		this.club = club;
 	}
 

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/entity/SubmissionForm.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/entity/SubmissionForm.java
@@ -7,14 +7,12 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import org.hibernate.annotations.SQLDelete;
 
 import com.example.cluvrapi.domain.club.entity.Club;
 import com.example.cluvrapi.domain.common.entity.BaseTimeEntity;
@@ -22,7 +20,6 @@ import com.example.cluvrapi.domain.common.entity.BaseTimeEntity;
 @Entity
 @Getter
 @Table(name = "submission_forms")
-@SQLDelete(sql = "UPDATE submission_forms SET is_deleted = true WHERE id = ?")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SubmissionForm extends BaseTimeEntity {
 
@@ -39,15 +36,9 @@ public class SubmissionForm extends BaseTimeEntity {
 	/**
 	 * 클럽
 	 */
-	@ManyToOne(fetch = FetchType.LAZY)
+	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "club_id", nullable = false)
 	private Club club;
-
-	/**
-	 * Soft Deleted
-	 */
-	@Column(nullable = false)
-	private Boolean isDeleted = false;
 
 	/**
 	 * 생성자 메서드

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/entity/SubmissionForm.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/entity/SubmissionForm.java
@@ -54,4 +54,8 @@ public class SubmissionForm extends BaseTimeEntity {
 	public void updateSubmissionTemplate(String submissionTemplate) {
 		this.submissionTemplate = submissionTemplate;
 	}
+
+	public void setClub(Club club) {
+		this.club = club;
+	}
 }

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/repository/ProblemFormRepositoryCustom.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/repository/ProblemFormRepositoryCustom.java
@@ -47,5 +47,15 @@ public interface ProblemFormRepositoryCustom {
 
 	PageResponseDto<InfoProblemFormResponseDto> findByProblemFormAllById(Long clubId, Pageable pageable);
 
-	Optional<Long> findActiveProblemFormIdByClubId(Long clubId);
+	/**
+	 * 설명: 클럽의 활성화된 문제양식 ID를 조회하는 메서드
+	 *
+	 * <p> SoftDelete가 적용된 데이터 제외, 단건 조회
+	 *
+	 * @param clubId {설명: 클럽 고유 식별자}
+	 * @return Optional<ProblemForm> {설명: 활성화된 문제양식 (없을 경우 빈 Optional)}
+	 * @author sinyoung0403
+	 */
+
+	Optional<ProblemForm> findActiveProblemFormIdByClubId(Long clubId);
 }

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/repository/ProblemFormRepositoryCustom.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/repository/ProblemFormRepositoryCustom.java
@@ -57,5 +57,5 @@ public interface ProblemFormRepositoryCustom {
 	 * @author sinyoung0403
 	 */
 
-	Optional<ProblemForm> findActiveProblemFormIdByClubId(Long clubId);
+	Optional<ProblemForm> findActiveProblemFormByClubId(Long clubId);
 }

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/repository/ProblemFormRepositoryImpl.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/repository/ProblemFormRepositoryImpl.java
@@ -34,9 +34,11 @@ public class ProblemFormRepositoryImpl implements ProblemFormRepositoryCustom {
 	public InfoProblemFormResponseDto findProblemFormById(Long clubId, Long problemId) {
 		InfoProblemFormResponseDto content = jpaQueryFactory
 			.select(new QInfoProblemFormResponseDto(
+				problemForm.id,
 				problemForm.problemTemplate,
 				problemForm.submissionInstructions,
-				problemForm.gradingCriteria
+				problemForm.gradingCriteria,
+				problemForm.isActive
 			))
 			.from(problemForm)
 			.where(problemForm.id.eq(problemId).and(problemForm.club.id.eq(clubId)))
@@ -48,9 +50,11 @@ public class ProblemFormRepositoryImpl implements ProblemFormRepositoryCustom {
 	public PageResponseDto<InfoProblemFormResponseDto> findByProblemFormAllById(Long clubId, Pageable pageable) {
 		List<InfoProblemFormResponseDto> content = jpaQueryFactory
 			.select(new QInfoProblemFormResponseDto(
+				problemForm.id,
 				problemForm.problemTemplate,
 				problemForm.submissionInstructions,
-				problemForm.gradingCriteria
+				problemForm.gradingCriteria,
+				problemForm.isActive
 			))
 			.from(problemForm)
 			.where(problemForm.club.id.eq(clubId))
@@ -68,9 +72,9 @@ public class ProblemFormRepositoryImpl implements ProblemFormRepositoryCustom {
 	}
 
 	@Override
-	public Optional<Long> findActiveProblemFormIdByClubId(Long clubId) {
+	public Optional<ProblemForm> findActiveProblemFormIdByClubId(Long clubId) {
 		return Optional.ofNullable(
-			jpaQueryFactory.select(problemForm.id)
+			jpaQueryFactory.select(problemForm)
 				.from(problemForm)
 				.where(
 					problemForm.club.id.eq(clubId)

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/repository/ProblemFormRepositoryImpl.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/repository/ProblemFormRepositoryImpl.java
@@ -78,8 +78,8 @@ public class ProblemFormRepositoryImpl implements ProblemFormRepositoryCustom {
 				.from(problemForm)
 				.where(
 					problemForm.club.id.eq(clubId)
-						.and(problemForm.isDeleted.eq(false))
-						.and(problemForm.isActive.eq(true))
+						.and(problemForm.isDeleted.isFalse())
+						.and(problemForm.isActive.isTrue())
 				)
 				.fetchOne()
 		);

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/repository/ProblemFormRepositoryImpl.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/repository/ProblemFormRepositoryImpl.java
@@ -72,7 +72,7 @@ public class ProblemFormRepositoryImpl implements ProblemFormRepositoryCustom {
 	}
 
 	@Override
-	public Optional<ProblemForm> findActiveProblemFormIdByClubId(Long clubId) {
+	public Optional<ProblemForm> findActiveProblemFormByClubId(Long clubId) {
 		return Optional.ofNullable(
 			jpaQueryFactory.select(problemForm)
 				.from(problemForm)

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/repository/SubmissionFormRepositoryCustom.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/repository/SubmissionFormRepositoryCustom.java
@@ -47,5 +47,5 @@ public interface SubmissionFormRepositoryCustom {
 
 	PageResponseDto<InfoSubmissionFormResponseDto> findAllSubmissionFormById(Long clubId, Pageable pageable);
 
-	Long findSubmissionFormIdByClubId(Long clubId);
+	Optional<SubmissionForm> findSubmissionFormByClubId(Long clubId);
 }

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/repository/SubmissionFormRepositoryImpl.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/repository/SubmissionFormRepositoryImpl.java
@@ -60,11 +60,12 @@ public class SubmissionFormRepositoryImpl implements SubmissionFormRepositoryCus
 	}
 
 	@Override
-	public Long findSubmissionFormIdByClubId(Long clubId) {
-		Long formId = jpaQueryFactory.select(submissionForm.id)
-			.from(submissionForm)
-			.where(submissionForm.club.id.eq(clubId))
-			.fetchFirst();
-		return formId;
+	public Optional<SubmissionForm> findSubmissionFormByClubId(Long clubId) {
+		return Optional.ofNullable(
+			jpaQueryFactory.select(submissionForm)
+				.from(submissionForm)
+				.where(submissionForm.club.id.eq(clubId))
+				.fetchFirst()
+		);
 	}
 }

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/repository/SubmissionFormRepositoryImpl.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/repository/SubmissionFormRepositoryImpl.java
@@ -63,7 +63,7 @@ public class SubmissionFormRepositoryImpl implements SubmissionFormRepositoryCus
 	public Long findSubmissionFormIdByClubId(Long clubId) {
 		Long formId = jpaQueryFactory.select(submissionForm.id)
 			.from(submissionForm)
-			.where(submissionForm.club.id.eq(clubId).and(submissionForm.isDeleted.eq(false)))
+			.where(submissionForm.club.id.eq(clubId))
 			.fetchFirst();
 		return formId;
 	}

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/service/ProblemFormService.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/service/ProblemFormService.java
@@ -14,6 +14,7 @@ public interface ProblemFormService {
 	/**
 	 * 설명: 클럽의 문제양식을 생성하는 메서드
 	 *
+	 * @param userId                      {설명: 유저의 고유 식별자}
 	 * @param clubId                      {설명: 클럽의 고유 식별자}
 	 * @param createProblemFormRequestDto {설명: 문제 양식에 필요한 정보}
 	 * @return CreateProblemFormResponseDto {설명: 클럽의 id 값 반환}
@@ -21,8 +22,8 @@ public interface ProblemFormService {
 	 * @author sinyoung0403
 	 */
 
-	CreateProblemFormResponseDto createProblemForm(Long clubId,
-		CreateProblemFormRequestDto createProblemFormRequestDto);
+	CreateProblemFormResponseDto createProblemForm(Long userId,
+		Long clubId, CreateProblemFormRequestDto createProblemFormRequestDto);
 
 	/**
 	 * 설명: 클럽의 문제양식을 단건조회하는 메서드
@@ -51,6 +52,7 @@ public interface ProblemFormService {
 	/**
 	 * 설명: 클럽의 문제양식을 수정하는 메서드
 	 *
+	 * @param userId                      {설명: 유저의 고유 식별자}
 	 * @param clubId                      {설명: 클럽의 고유 식별자}
 	 * @param problemFormId               {설명: problemForm 의 고유 식별자}
 	 * @param updateProblemFormRequestDto {설명: 수정할 때 필요한 정보}
@@ -58,19 +60,33 @@ public interface ProblemFormService {
 	 * @author sinyoung0403
 	 */
 
-	void updateProblemForm(Long clubId, Long problemFormId,
-		UpdateProblemFormRequestDto updateProblemFormRequestDto);
+	void updateProblemForm(Long userId, Long clubId,
+		Long problemFormId, UpdateProblemFormRequestDto updateProblemFormRequestDto);
 
 	/**
 	 * 설명: 클럽의 문제양식을 삭제하는 메서드
 	 *
 	 * <p> 양식을 삭제 시 SoftDeleted 처리 및 Club 의 JoinType 이 가입 신청 양식으로 변경
 	 *
+	 * @param userId        {설명: 유저의 고유 식별자}
 	 * @param clubId        {설명: 클럽의 고유 식별자}
 	 * @param problemFormId {설명: problemForm 의 고유 식별자}
 	 * @throws BusinessException {404 NotFound}
 	 * @author sinyoung0403
 	 */
 
-	void deleteProblem(Long clubId, Long problemFormId);
+	void deleteProblem(Long userId, Long clubId, Long problemFormId);
+
+	/**
+	 * 설명: 클럽 문제양식의 활성화 상태를 변경하는 메서드
+	 *
+	 * @param id            {설명: 요청자(사용자)의 고유 식별자}
+	 * @param clubId        {설명: 클럽의 고유 식별자}
+	 * @param problemFormId {설명: 문제양식의 고유 식별자}
+	 * @param active        {설명: 활성화 여부 (true: 활성화, false: 비활성화)}
+	 * @throws BusinessException {404 NotFound} 문제양식 또는 클럽을 찾지 못했을 경우
+	 * @author sinyoung0403
+	 */
+
+	void changeActivationState(Long id, Long clubId, Long problemFormId, Boolean active);
 }

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/service/ProblemFormService.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/service/ProblemFormService.java
@@ -50,6 +50,17 @@ public interface ProblemFormService {
 	PageResponseDto<InfoProblemFormResponseDto> findAllProblemForm(Long clubId, Pageable pageable);
 
 	/**
+	 * 설명: 클럽의 활성화된 문제양식을 조회하는 메서드
+	 *
+	 * @param clubId {설명: 클럽의 고유 식별자}
+	 * @return InfoProblemFormResponseDto {설명: 활성 문제양식 응답 DTO}
+	 * @throws BusinessException {404 NotFound} 활성 문제양식이 없을 경우
+	 * @author sinyoung0403
+	 */
+
+	InfoProblemFormResponseDto findActiveProblemFormByClubId(Long clubId);
+
+	/**
 	 * 설명: 클럽의 문제양식을 수정하는 메서드
 	 *
 	 * @param userId                      {설명: 유저의 고유 식별자}

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/service/ProblemFormServiceImpl.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/service/ProblemFormServiceImpl.java
@@ -34,6 +34,7 @@ public class ProblemFormServiceImpl implements ProblemFormService {
 	private final ClubMemberRepository clubMemberRepository;
 
 	@Override
+	@Transactional
 	public CreateProblemFormResponseDto createProblemForm(Long userId,
 		Long clubId, CreateProblemFormRequestDto problemFormRequestDto) {
 		// 1) Club 조회
@@ -47,7 +48,7 @@ public class ProblemFormServiceImpl implements ProblemFormService {
 
 		// 3) Club 의 JoinType 이 ProblemForm 인지 검증
 		if (findClub.getJoinType() != JoinType.PROBLEM_FORM) {
-			new BusinessException(ResponseCode.INVALID_REQUEST);
+			throw new BusinessException(ResponseCode.INVALID_REQUEST);
 		}
 
 		// 4) Form Entity 생성
@@ -60,7 +61,7 @@ public class ProblemFormServiceImpl implements ProblemFormService {
 		);
 
 		// 5) 활성화된 문제 양식을 비활성화로 바꾸어준다.
-		Optional<ProblemForm> formOpt = problemRepository.findActiveProblemFormIdByClubId(clubId);
+		Optional<ProblemForm> formOpt = problemRepository.findActiveProblemFormByClubId(clubId);
 		formOpt.ifPresent(
 			form -> {
 				form.deactivate();
@@ -74,18 +75,21 @@ public class ProblemFormServiceImpl implements ProblemFormService {
 	}
 
 	@Override
+	@Transactional(readOnly = true)
 	public InfoProblemFormResponseDto findProblemFormById(Long clubId, Long problemId) {
 		return problemRepository.findProblemFormById(clubId, problemId);
 	}
 
 	@Override
+	@Transactional(readOnly = true)
 	public PageResponseDto<InfoProblemFormResponseDto> findAllProblemForm(Long clubId, Pageable pageable) {
 		return problemRepository.findByProblemFormAllById(clubId, pageable);
 	}
 
 	@Override
+	@Transactional(readOnly = true)
 	public InfoProblemFormResponseDto findActiveProblemFormByClubId(Long clubId) {
-		ProblemForm activeProblemForm = problemRepository.findActiveProblemFormIdByClubId(clubId).orElseThrow(
+		ProblemForm activeProblemForm = problemRepository.findActiveProblemFormByClubId(clubId).orElseThrow(
 			() -> new BusinessException(ResponseCode.INVALID_REQUEST, "활성화된 문제양식이 없습니다.")
 		);
 		return InfoProblemFormResponseDto.from(activeProblemForm);
@@ -167,7 +171,7 @@ public class ProblemFormServiceImpl implements ProblemFormService {
 		// 3) 활성화 및 비활성화
 		if (active) {
 			// 활성화를 한다고 할 경우, 기존 문제양식 비활성화
-			Optional<ProblemForm> formOpt = problemRepository.findActiveProblemFormIdByClubId(clubId);
+			Optional<ProblemForm> formOpt = problemRepository.findActiveProblemFormByClubId(clubId);
 			formOpt.ifPresent(
 				form -> {
 					form.deactivate();

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/service/ProblemFormServiceImpl.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/service/ProblemFormServiceImpl.java
@@ -1,5 +1,7 @@
 package com.example.cluvrapi.domain.applicationForm.service;
 
+import java.util.Optional;
+
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.data.domain.Pageable;
@@ -48,15 +50,24 @@ public class ProblemFormServiceImpl implements ProblemFormService {
 			new BusinessException(ResponseCode.INVALID_REQUEST);
 		}
 
-		// 3) Form Entity 생성
+		// 4) Form Entity 생성
 		ProblemForm problemForm = new ProblemForm(
 			problemFormRequestDto.getProblemTemplate(),
 			problemFormRequestDto.getSubmissionInstructions(),
 			problemFormRequestDto.getGradingCriteria(),
+			true,
 			findClub
 		);
 
-		// 4) 저장
+		// 5) 활성화된 문제 양식을 비활성화로 바꾸어준다.
+		Optional<ProblemForm> formOpt = problemRepository.findActiveProblemFormIdByClubId(clubId);
+		formOpt.ifPresent(
+			form -> {
+				form.deactivate();
+			}
+		);
+
+		// 6) 저장
 		problemRepository.save(problemForm);
 
 		return CreateProblemFormResponseDto.from(problemForm.getId());
@@ -70,6 +81,14 @@ public class ProblemFormServiceImpl implements ProblemFormService {
 	@Override
 	public PageResponseDto<InfoProblemFormResponseDto> findAllProblemForm(Long clubId, Pageable pageable) {
 		return problemRepository.findByProblemFormAllById(clubId, pageable);
+	}
+
+	@Override
+	public InfoProblemFormResponseDto findActiveProblemFormByClubId(Long clubId) {
+		ProblemForm activeProblemForm = problemRepository.findActiveProblemFormIdByClubId(clubId).orElseThrow(
+			() -> new BusinessException(ResponseCode.INVALID_REQUEST, "활성화된 문제양식이 없습니다.")
+		);
+		return InfoProblemFormResponseDto.from(activeProblemForm);
 	}
 
 	@Override
@@ -89,17 +108,17 @@ public class ProblemFormServiceImpl implements ProblemFormService {
 				new BusinessException(ResponseCode.NOT_FOUND, "Club 과 Problem Form 이 일치하는 Entity 가 존재하지 않습니다.")
 			);
 
-		// 2) Template 수정
+		// 3) Template 수정
 		if (updateProblemFormRequestDto.getProblemTemplate() != null) {
 			findProblemForm.updateProblemForm(updateProblemFormRequestDto.getProblemTemplate());
 		}
 
-		// 3) SubmissionInstructions 수정
+		// 4) SubmissionInstructions 수정
 		if (updateProblemFormRequestDto.getSubmissionInstructions() != null) {
 			findProblemForm.updateSubmissionInstructions(updateProblemFormRequestDto.getSubmissionInstructions());
 		}
 
-		// 4) GradingCriteria 수정
+		// 5) GradingCriteria 수정
 		if (updateProblemFormRequestDto.getGradingCriteria() != null) {
 			findProblemForm.updateGradingCriteria(updateProblemFormRequestDto.getGradingCriteria());
 		}
@@ -125,12 +144,38 @@ public class ProblemFormServiceImpl implements ProblemFormService {
 		// 3) 삭제 - soft Delete 적용
 		problemRepository.delete(findProblemForm);
 
-		// 3) 비활성화
+		// 4) 비활성화
 		findProblemForm.deactivate();
+	}
+
+	@Override
+	@Transactional
+	public void changeActivationState(Long userId, Long clubId, Long problemFormId, Boolean active) {
 		// 1) 권한 검증
 		ClubMember findClubMember = clubMemberRepository.findByClubIdAndUserId(clubId, userId).orElseThrow(
 			() -> new BusinessException(ResponseCode.INVALID_REQUEST, "해당하는 멤버가 존재하지 않습니다.")
 		);
 		clubValidator.validateOwnerRole(findClubMember.getClubMemberRole());
+
+		// 2) 문제양식 조회
+		ProblemForm findProblemForm = problemRepository.findByIdOrElseThrow(problemFormId);
+
+		if (findProblemForm.getIsActive() == active) {
+			throw new BusinessException(ResponseCode.INVALID_REQUEST, "이미 해당 상태입니다.");
+		}
+
+		// 3) 활성화 및 비활성화
+		if (active) {
+			// 활성화를 한다고 할 경우, 기존 문제양식 비활성화
+			Optional<ProblemForm> formOpt = problemRepository.findActiveProblemFormIdByClubId(clubId);
+			formOpt.ifPresent(
+				form -> {
+					form.deactivate();
+				}
+			);
+			findProblemForm.activate();
+		} else { // 비활성화
+			findProblemForm.deactivate();
+		}
 	}
 }

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/service/ProblemFormServiceImpl.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/service/ProblemFormServiceImpl.java
@@ -15,7 +15,10 @@ import com.example.cluvrapi.domain.applicationForm.repository.ProblemFormReposit
 import com.example.cluvrapi.domain.club.entity.Club;
 import com.example.cluvrapi.domain.club.enums.JoinType;
 import com.example.cluvrapi.domain.club.repository.ClubRepository;
+import com.example.cluvrapi.domain.clubMember.entity.ClubMember;
+import com.example.cluvrapi.domain.clubMember.repository.ClubMemberRepository;
 import com.example.cluvrapi.domain.common.dto.PageResponseDto;
+import com.example.cluvrapi.domain.common.validator.ClubValidator;
 import com.example.cluvrapi.global.exception.BusinessException;
 import com.example.cluvrapi.global.response.ResponseCode;
 
@@ -25,14 +28,22 @@ public class ProblemFormServiceImpl implements ProblemFormService {
 
 	private final ClubRepository clubRepository;
 	private final ProblemFormRepository problemRepository;
+	private final ClubValidator clubValidator;
+	private final ClubMemberRepository clubMemberRepository;
 
 	@Override
-	public CreateProblemFormResponseDto createProblemForm(Long clubId,
-		CreateProblemFormRequestDto problemFormRequestDto) {
+	public CreateProblemFormResponseDto createProblemForm(Long userId,
+		Long clubId, CreateProblemFormRequestDto problemFormRequestDto) {
 		// 1) Club 조회
 		Club findClub = clubRepository.findByIdOrElseThrow(clubId);
 
-		// 2) Club 의 JoinType 이 ProblemForm 인지 검증
+		// 2) 권한 검증
+		ClubMember findClubMember = clubMemberRepository.findByClubIdAndUserId(clubId, userId).orElseThrow(
+			() -> new BusinessException(ResponseCode.INVALID_REQUEST, "해당하는 멤버가 존재하지 않습니다.")
+		);
+		clubValidator.validateOwnerRole(findClubMember.getClubMemberRole());
+
+		// 3) Club 의 JoinType 이 ProblemForm 인지 검증
 		if (findClub.getJoinType() != JoinType.PROBLEM_FORM) {
 			new BusinessException(ResponseCode.INVALID_REQUEST);
 		}
@@ -63,9 +74,16 @@ public class ProblemFormServiceImpl implements ProblemFormService {
 
 	@Override
 	@Transactional
-	public void updateProblemForm(Long clubId, Long problemFormId,
-		UpdateProblemFormRequestDto updateProblemFormRequestDto) {
-		// 1) Problem Form 조회
+	public void updateProblemForm(Long userId, Long clubId,
+		Long problemFormId, UpdateProblemFormRequestDto updateProblemFormRequestDto) {
+
+		// 1) 권한 검증
+		ClubMember findClubMember = clubMemberRepository.findByClubIdAndUserId(clubId, userId).orElseThrow(
+			() -> new BusinessException(ResponseCode.INVALID_REQUEST, "해당하는 멤버가 존재하지 않습니다.")
+		);
+		clubValidator.validateOwnerRole(findClubMember.getClubMemberRole());
+
+		// 2) Problem Form 조회
 		ProblemForm findProblemForm = problemRepository.findByClubIdAndProblemFormId(clubId, problemFormId)
 			.orElseThrow(() ->
 				new BusinessException(ResponseCode.NOT_FOUND, "Club 과 Problem Form 이 일치하는 Entity 가 존재하지 않습니다.")
@@ -90,17 +108,29 @@ public class ProblemFormServiceImpl implements ProblemFormService {
 
 	@Override
 	@Transactional
-	public void deleteProblem(Long clubId, Long problemFormId) {
-		// 1) Problem Form 조회
+	public void deleteProblem(Long userId, Long clubId, Long problemFormId) {
+
+		// 1) 권한 검증
+		ClubMember findClubMember = clubMemberRepository.findByClubIdAndUserId(clubId, userId).orElseThrow(
+			() -> new BusinessException(ResponseCode.INVALID_REQUEST, "해당하는 멤버가 존재하지 않습니다.")
+		);
+		clubValidator.validateOwnerRole(findClubMember.getClubMemberRole());
+
+		// 2) Problem Form 조회
 		ProblemForm findProblemForm = problemRepository.findByClubIdAndProblemFormId(clubId, problemFormId)
 			.orElseThrow(() ->
 				new BusinessException(ResponseCode.NOT_FOUND, "Club 과 Problem Form 이 일치하는 Entity 가 존재하지 않습니다.")
 			);
 
-		// 2) 삭제 - soft Delete 적용
+		// 3) 삭제 - soft Delete 적용
 		problemRepository.delete(findProblemForm);
 
 		// 3) 비활성화
 		findProblemForm.deactivate();
+		// 1) 권한 검증
+		ClubMember findClubMember = clubMemberRepository.findByClubIdAndUserId(clubId, userId).orElseThrow(
+			() -> new BusinessException(ResponseCode.INVALID_REQUEST, "해당하는 멤버가 존재하지 않습니다.")
+		);
+		clubValidator.validateOwnerRole(findClubMember.getClubMemberRole());
 	}
 }

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/service/ProblemFormServiceImpl.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/service/ProblemFormServiceImpl.java
@@ -161,11 +161,15 @@ public class ProblemFormServiceImpl implements ProblemFormService {
 		);
 		clubValidator.validateOwnerRole(findClubMember.getClubMemberRole());
 
-		// 2) 문제양식 조회
+		// 2) 문제양식 조회 및 권한 검증
 		ProblemForm findProblemForm = problemRepository.findByIdOrElseThrow(problemFormId);
 
 		if (findProblemForm.getIsActive() == active) {
 			throw new BusinessException(ResponseCode.INVALID_REQUEST, "이미 해당 상태입니다.");
+		}
+
+		if (!findProblemForm.getClub().getId().equals(clubId)) {
+			throw new BusinessException(ResponseCode.INVALID_REQUEST, "클럽과 문제양식의 소속이 일치하지 않습니다.");
 		}
 
 		// 3) 활성화 및 비활성화

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/service/SubmissionFormService.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/service/SubmissionFormService.java
@@ -14,6 +14,7 @@ public interface SubmissionFormService {
 	/**
 	 * 설명: 클럽의 제출 양식을 생성하는 메서드
 	 *
+	 * @param userId                   {설명: 클럽의 고유 식별자}
 	 * @param clubId                   {설명: 클럽의 고유 식별자}
 	 * @param submissionFormRequestDto {설명: 가입 제출 양식에 필요한 정보}
 	 * @return CreateSubmissionFormResponseDto {설명: 클럽의 id 값 반환}
@@ -21,8 +22,8 @@ public interface SubmissionFormService {
 	 * @author sinyoung0403
 	 */
 
-	CreateSubmissionFormResponseDto createSubmissionForm(Long clubId,
-		CreateSubmissionFormRequestDto submissionFormRequestDto);
+	CreateSubmissionFormResponseDto createSubmissionForm(Long userId,
+		Long clubId, CreateSubmissionFormRequestDto submissionFormRequestDto);
 
 	/**
 	 * 설명: 클럽의 제출양식을 단건조회하는 메서드
@@ -49,6 +50,7 @@ public interface SubmissionFormService {
 	/**
 	 * 설명: 클럽의 제출 양식을 수정하는 메서드
 	 *
+	 * @param userId
 	 * @param clubId
 	 * @param submissionFormId                   {설명: ApplicationForm 의 고유 식별자}
 	 * @param updateSubmissionTemplateRequestDto {설명: 수정할 때 필요한 정보}
@@ -56,19 +58,20 @@ public interface SubmissionFormService {
 	 * @author sinyoung0403
 	 */
 
-	void updateSubmissionTemplate(Long clubId, Long submissionFormId,
-		UpdateSubmissionTemplateRequestDto updateSubmissionTemplateRequestDto);
+	void updateSubmissionTemplate(Long userId, Long clubId,
+		Long submissionFormId, UpdateSubmissionTemplateRequestDto updateSubmissionTemplateRequestDto);
 
 	/**
 	 * 설명: 클럽의 제출 양식을 삭제하는 메서드
 	 *
 	 * <p> 양식을 삭제 시 SoftDeleted 처리 및 Club 의 JoinType 이 가입 신청 양식으로 변경
 	 *
+	 * @param userId           {설명: 클럽 의 고유 식별자}
 	 * @param clubId           {설명: 클럽 의 고유 식별자}
 	 * @param submissionFormId {설명: SubmissionForm 의 고유 식별자}
 	 * @throws BusinessException {404 NotFound}
 	 * @author sinyoung0403
 	 */
 
-	void deleteSubmissionForm(Long clubId, Long submissionFormId);
+	void deleteSubmissionForm(Long userId, Long clubId, Long submissionFormId);
 }

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/service/SubmissionFormServiceImpl.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/service/SubmissionFormServiceImpl.java
@@ -15,7 +15,10 @@ import com.example.cluvrapi.domain.applicationForm.repository.SubmissionFormRepo
 import com.example.cluvrapi.domain.club.entity.Club;
 import com.example.cluvrapi.domain.club.enums.JoinType;
 import com.example.cluvrapi.domain.club.repository.ClubRepository;
+import com.example.cluvrapi.domain.clubMember.entity.ClubMember;
+import com.example.cluvrapi.domain.clubMember.repository.ClubMemberRepository;
 import com.example.cluvrapi.domain.common.dto.PageResponseDto;
+import com.example.cluvrapi.domain.common.validator.ClubValidator;
 import com.example.cluvrapi.global.exception.BusinessException;
 import com.example.cluvrapi.global.response.ResponseCode;
 
@@ -25,28 +28,44 @@ public class SubmissionFormServiceImpl implements SubmissionFormService {
 
 	private final SubmissionFormRepository submissionFormRepository;
 	private final ClubRepository clubRepository;
+	private final ClubMemberRepository clubMemberRepository;
+	private final ClubValidator clubValidator;
 
 	@Override
 	@Transactional
 	public CreateSubmissionFormResponseDto createSubmissionForm(
-		Long clubId,
-		CreateSubmissionFormRequestDto submissionFormRequestDto
+		Long userId,
+		Long clubId, CreateSubmissionFormRequestDto submissionFormRequestDto
 	) {
 		// 1) Club 조회
 		Club findClub = clubRepository.findByIdOrElseThrow(clubId);
 
-		// 2) Club 의 JoinType 이 ProblemForm 인지 검증
+		// 2) 멤버 권한 검증
+		ClubMember findClubMember = clubMemberRepository.findByClubIdAndUserId(clubId, userId).orElseThrow(
+			() -> new BusinessException(ResponseCode.INVALID_REQUEST, "해당하는 멤버가 존재하지 않습니다.")
+		);
+		clubValidator.validateOwnerRole(findClubMember.getClubMemberRole());
+
+		// 3) Club 의 JoinType 이 SubmissionForm 인지 검증
 		if (findClub.getJoinType() != JoinType.SUBMISSION_FORM) {
-			new BusinessException(ResponseCode.INVALID_REQUEST);
+			throw new BusinessException(ResponseCode.INVALID_REQUEST, "가입방식이 `SubmissionForm`과 동일하지 않습니다.");
 		}
 
-		// 3) Form Entity 생성
+		// 4) 이미 존재하고 있다면, 생성 불가
+		if (findClub.getSubmissionForm() != null) {
+			throw new BusinessException(ResponseCode.INVALID_REQUEST, "이미 양식 존재합니다.");
+		}
+
+		// 5) Form Entity 생성
 		SubmissionForm submissionForm = new SubmissionForm(
 			submissionFormRequestDto.getSubmissionForm(),
 			findClub
 		);
 
-		// 4) 저장
+		// 6) 연관관계 주입
+		findClub.setSubmissionForm(submissionForm);
+
+		// 7) 저장
 		submissionFormRepository.save(submissionForm);
 
 		return CreateSubmissionFormResponseDto.from(submissionForm.getId());
@@ -67,17 +86,24 @@ public class SubmissionFormServiceImpl implements SubmissionFormService {
 	@Override
 	@Transactional
 	public void updateSubmissionTemplate(
+		Long userId,
 		Long clubId,
-		Long submissionId,
-		UpdateSubmissionTemplateRequestDto updateSubmissionTemplateRequestDto
+		Long submissionFormId, UpdateSubmissionTemplateRequestDto updateSubmissionTemplateRequestDto
 	) {
-		// 1) Submission Form 조회
-		SubmissionForm findSubmissionForm = submissionFormRepository.findByClubIdAndSubmissionId(clubId, submissionId)
+		// 1) 멤버 권한 검증
+		ClubMember findClubMember = clubMemberRepository.findByClubIdAndUserId(clubId, userId).orElseThrow(
+			() -> new BusinessException(ResponseCode.INVALID_REQUEST, "해당하는 멤버가 존재하지 않습니다.")
+		);
+		clubValidator.validateOwnerRole(findClubMember.getClubMemberRole());
+
+		// 2) Submission Form 조회
+		SubmissionForm findSubmissionForm = submissionFormRepository.findByClubIdAndSubmissionId(clubId,
+				submissionFormId)
 			.orElseThrow(() ->
 				new BusinessException(ResponseCode.NOT_FOUND, "Club 과 Submission Form 이 일치하는 Entity 가 존재하지 않습니다.")
 			);
 
-		// 2) Template 수정
+		// 3) Template 수정
 		if (updateSubmissionTemplateRequestDto.getSubmissionTemplate() != null) {
 			findSubmissionForm.updateSubmissionTemplate(updateSubmissionTemplateRequestDto.getSubmissionTemplate());
 		}
@@ -86,19 +112,25 @@ public class SubmissionFormServiceImpl implements SubmissionFormService {
 
 	@Override
 	@Transactional
-	public void deleteSubmissionForm(Long clubId, Long submissionId) {
-		// 1) Submission Form 조회
-		SubmissionForm findSubmissionForm = submissionFormRepository.findByClubIdAndSubmissionId(clubId, submissionId)
+	public void deleteSubmissionForm(Long userId, Long clubId, Long submissionFormId) {
+		// 1) 클럽 조회
+		Club club = clubRepository.findByIdOrElseThrow(clubId);
+
+		// 2) 멤버 권한 검증
+		ClubMember findClubMember = clubMemberRepository.findByClubIdAndUserId(clubId, userId).orElseThrow(
+			() -> new BusinessException(ResponseCode.INVALID_REQUEST, "해당하는 멤버가 존재하지 않습니다.")
+		);
+		clubValidator.validateOwnerRole(findClubMember.getClubMemberRole());
+
+		// 3) Submission Form 조회
+		SubmissionForm findSubmissionForm = submissionFormRepository.findByClubIdAndSubmissionId(clubId,
+				submissionFormId)
 			.orElseThrow(() ->
 				new BusinessException(ResponseCode.NOT_FOUND, "Club 과 Submission Form 이 일치하는 Entity 가 존재하지 않습니다.")
 			);
 
-		// 2) 삭제 - soft Delete 적용
+		// 4) 삭제
+		club.setSubmissionForm(null);
 		submissionFormRepository.delete(findSubmissionForm);
-
-		// 3) 즉시 가입 방식으로 변경
-		Club findClub = clubRepository.findByIdOrElseThrow(clubId);
-		findClub.updateJoinType(JoinType.DIRECT_JOIN);
 	}
-
 }

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/club/entity/Club.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/club/entity/Club.java
@@ -152,8 +152,8 @@ public class Club extends BaseTimeEntity {
 	 * 기본 생성자
 	 */
 
-	public Club(String name, ClubType clubType, int maxMemberCount, int minCloverRequirement,
-		String greeting, String description, String posterUrl, Boolean isPublic, JoinType joinType) {
+	public Club(String name, ClubType clubType, int maxMemberCount, int minCloverRequirement, String greeting,
+		String description, String posterUrl, Boolean isPublic, JoinType joinType) {
 		this.name = name;
 		this.clubType = clubType;
 		this.maxMemberCount = maxMemberCount;
@@ -251,6 +251,9 @@ public class Club extends BaseTimeEntity {
 
 	public void setSubmissionForm(SubmissionForm submissionForm) {
 		this.submissionForm = submissionForm;
+		if (this.submissionForm != null && this.submissionForm.getClub() == this) {
+			this.submissionForm.setClub(null);
+		}
 		if (submissionForm != null && submissionForm.getClub() != this) {
 			submissionForm.setClub(this);
 		}

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/club/entity/Club.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/club/entity/Club.java
@@ -251,5 +251,8 @@ public class Club extends BaseTimeEntity {
 
 	public void setSubmissionForm(SubmissionForm submissionForm) {
 		this.submissionForm = submissionForm;
+		if (submissionForm != null && submissionForm.getClub() != this) {
+			submissionForm.setClub(this);
+		}
 	}
 }

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/club/entity/Club.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/club/entity/Club.java
@@ -1,12 +1,15 @@
 package com.example.cluvrapi.domain.club.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 
 import lombok.AccessLevel;
@@ -16,6 +19,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
+import com.example.cluvrapi.domain.applicationForm.entity.SubmissionForm;
 import com.example.cluvrapi.domain.club.enums.ClubType;
 import com.example.cluvrapi.domain.club.enums.JoinType;
 import com.example.cluvrapi.domain.common.entity.BaseTimeEntity;
@@ -124,6 +128,12 @@ public class Club extends BaseTimeEntity {
 
 	@Column(name = "is_deleted", nullable = false)
 	private Boolean isDeleted = false;
+
+	/**
+	 * SubmissionForm 연관관계
+	 */
+	@OneToOne(mappedBy = "club", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+	private SubmissionForm submissionForm;
 
 	/**
 	 * 가입 방식:
@@ -237,5 +247,9 @@ public class Club extends BaseTimeEntity {
 		}
 
 		this.isPublic = isPublic;
+	}
+
+	public void setSubmissionForm(SubmissionForm submissionForm) {
+		this.submissionForm = submissionForm;
 	}
 }

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/common/validator/ClubValidator.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/common/validator/ClubValidator.java
@@ -1,0 +1,51 @@
+package com.example.cluvrapi.domain.common.validator;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Component;
+
+import com.example.cluvrapi.domain.club.dto.request.CreateClubRequestDto;
+import com.example.cluvrapi.domain.club.dto.request.UpdateClubRequestDto;
+import com.example.cluvrapi.domain.club.entity.Club;
+import com.example.cluvrapi.domain.club.repository.ClubRepository;
+import com.example.cluvrapi.domain.clubMember.entity.enums.ClubMemberRole;
+import com.example.cluvrapi.global.exception.BusinessException;
+import com.example.cluvrapi.global.response.ResponseCode;
+
+@Component
+@RequiredArgsConstructor
+public class ClubValidator {
+	private final ClubRepository clubRepository;
+
+	public void validateClubCreation(CreateClubRequestDto dto) {
+		if (clubRepository.existsByClubName(dto.getName())) {
+			throw new BusinessException(ResponseCode.INVALID_REQUEST, "클럽명 중복");
+		}
+		if (dto.getName().length() > 20) {
+			throw new BusinessException(ResponseCode.INVALID_REQUEST, "클럽명은 20자 이하");
+		}
+	}
+
+	public void validateClubInfoUpdate(UpdateClubRequestDto dto, Club club) {
+		if (dto.getName() != null && !dto.getName().equals(club.getName())) {
+			if (clubRepository.existsByClubName(dto.getName())) {
+				throw new BusinessException(ResponseCode.INVALID_REQUEST, "클럽명 중복");
+			}
+			if (dto.getName().length() > 20) {
+				throw new BusinessException(ResponseCode.INVALID_REQUEST, "클럽명은 20자 이하");
+			}
+		}
+	}
+
+	public void validateOwnerRole(ClubMemberRole role) {
+		if (role != ClubMemberRole.OWNER) {
+			throw new BusinessException(ResponseCode.ACCESS_DENIED, "클랜장만 가능");
+		}
+	}
+
+	public void validateOwnerAndAdminRole(ClubMemberRole role) {
+		if (role != ClubMemberRole.OWNER && role != ClubMemberRole.ADMIN) {
+			throw new BusinessException(ResponseCode.ACCESS_DENIED, "클랜장과 운영진만 가능합니다.");
+		}
+	}
+}

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/join/service/JoinServiceImpl.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/join/service/JoinServiceImpl.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.cluvrapi.domain.applicationForm.entity.ProblemForm;
 import com.example.cluvrapi.domain.applicationForm.repository.ProblemFormRepository;
 import com.example.cluvrapi.domain.applicationForm.repository.SubmissionFormRepository;
 import com.example.cluvrapi.domain.club.entity.Club;
@@ -291,11 +292,12 @@ public class JoinServiceImpl implements JoinService {
 		}
 
 		// 1) Form id 값 추출 - Active 한 Id 값을 가져온다.
-		Long problemFormId = problemFormRepository.findActiveProblemFormIdByClubId(clubId)
+		ProblemForm problemForm = problemFormRepository.findActiveProblemFormIdByClubId(clubId)
 			.orElseThrow(() -> new BusinessException(ResponseCode.INVALID_REQUEST, "잘못된 요청입니다."));
 
 		// 2) Entity 생성
-		JoinRequestAnswer joinRequestAnswer = new JoinRequestAnswer(joinRequest, problemFormId, FormFieldType.PROBLEM,
+		JoinRequestAnswer joinRequestAnswer = new JoinRequestAnswer(joinRequest, problemForm.getId(),
+			FormFieldType.PROBLEM,
 			answers);
 
 		// 3. 저장

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/join/service/JoinServiceImpl.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/join/service/JoinServiceImpl.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.cluvrapi.domain.applicationForm.entity.ProblemForm;
+import com.example.cluvrapi.domain.applicationForm.entity.SubmissionForm;
 import com.example.cluvrapi.domain.applicationForm.repository.ProblemFormRepository;
 import com.example.cluvrapi.domain.applicationForm.repository.SubmissionFormRepository;
 import com.example.cluvrapi.domain.club.entity.Club;
@@ -264,10 +265,12 @@ public class JoinServiceImpl implements JoinService {
 		}
 
 		// 1) Form 의 id 값 추출
-		Long submissionFormId = submissionFormRepository.findSubmissionFormIdByClubId(clubId);
+		SubmissionForm submissionForm = submissionFormRepository.findSubmissionFormByClubId(clubId).orElseThrow(
+			() -> new BusinessException(ResponseCode.NOT_FOUND, "해당하는 클럽의 가입양식은 현재 존재하지 않습니다.")
+		);
 
 		// 2) Entity 생성
-		JoinRequestAnswer joinRequestAnswer = new JoinRequestAnswer(joinRequest, submissionFormId,
+		JoinRequestAnswer joinRequestAnswer = new JoinRequestAnswer(joinRequest, submissionForm.getId(),
 			FormFieldType.SUBMISSION, answers);
 
 		// 3) 저장
@@ -292,7 +295,7 @@ public class JoinServiceImpl implements JoinService {
 		}
 
 		// 1) Form id 값 추출 - Active 한 Id 값을 가져온다.
-		ProblemForm problemForm = problemFormRepository.findActiveProblemFormIdByClubId(clubId)
+		ProblemForm problemForm = problemFormRepository.findActiveProblemFormByClubId(clubId)
 			.orElseThrow(() -> new BusinessException(ResponseCode.INVALID_REQUEST, "잘못된 요청입니다."));
 
 		// 2) Entity 생성

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/notice/controller/NoticeController.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/notice/controller/NoticeController.java
@@ -16,6 +16,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.example.cluvrapi.domain.common.annotation.Auth;
+import com.example.cluvrapi.domain.common.dto.AuthUser;
 import com.example.cluvrapi.domain.common.dto.PageResponseDto;
 import com.example.cluvrapi.domain.notice.dto.reqeust.CreateNoticeRequestDto;
 import com.example.cluvrapi.domain.notice.dto.reqeust.UpdateNoticeRequestDto;
@@ -34,10 +36,11 @@ public class NoticeController {
 
 	@PostMapping
 	public ResponseEntity<BaseResponse<CreateNoticeResponseDto>> createNotice(
+		@Auth AuthUser authUser,
 		@PathVariable Long clubId,
 		@RequestBody CreateNoticeRequestDto createNoticeRequestDto
 	) {
-		CreateNoticeResponseDto createNoticeResponseDto = noticeService.createNotice(1L, clubId,
+		CreateNoticeResponseDto createNoticeResponseDto = noticeService.createNotice(authUser.id(), clubId,
 			createNoticeRequestDto);
 		return ResponseEntity.ok(BaseResponse.success(createNoticeResponseDto, ResponseCode.CREATED));
 	}
@@ -62,18 +65,22 @@ public class NoticeController {
 
 	@PatchMapping("/{noticeId}")
 	public ResponseEntity<BaseResponse<Void>> updateNotice(
+		@Auth AuthUser authUser,
+		@PathVariable Long clubId,
 		@PathVariable Long noticeId,
 		@Valid @RequestBody UpdateNoticeRequestDto updateNoticeRequestDto
 	) {
-		noticeService.updateNotice(noticeId, updateNoticeRequestDto);
+		noticeService.updateNotice(authUser.id(), clubId, noticeId, updateNoticeRequestDto);
 		return ResponseEntity.ok(BaseResponse.success(ResponseCode.OK));
 	}
 
 	@DeleteMapping("/{noticeId}")
 	public ResponseEntity<BaseResponse<Void>> deleteNotice(
+		@Auth AuthUser authUser,
+		@PathVariable Long clubId,
 		@PathVariable Long noticeId
 	) {
-		noticeService.deleteNotice(noticeId);
+		noticeService.deleteNotice(authUser.id(), clubId, noticeId);
 		return ResponseEntity.ok(BaseResponse.success(ResponseCode.OK));
 	}
 

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/notice/repository/NoticeRepositoryCustom.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/notice/repository/NoticeRepositoryCustom.java
@@ -1,5 +1,7 @@
 package com.example.cluvrapi.domain.notice.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Pageable;
 
 import com.example.cluvrapi.domain.common.dto.PageResponseDto;
@@ -17,7 +19,7 @@ public interface NoticeRepositoryCustom {
 	 * @return InfoNoticeResponseDto {공지사항 정보}
 	 * @author sinyoung0403
 	 */
-	InfoNoticeResponseDto findNoticeById(Long clubId, Long noticeId);
+	Optional<InfoNoticeResponseDto> findNoticeById(Long clubId, Long noticeId);
 
 	/**
 	 * 설명: 공지사항 다건 조회하는 쿼리문

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/notice/repository/NoticeRepositoryImpl.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/notice/repository/NoticeRepositoryImpl.java
@@ -31,7 +31,9 @@ public class NoticeRepositoryImpl implements NoticeRepositoryCustom {
 					notice.content
 				))
 				.from(notice)
-				.where(notice.id.eq(noticeId).and(notice.club.id.eq(clubId)))
+				.where(notice.id.eq(noticeId)
+					.and(notice.club.id.eq(clubId))
+					.and(notice.isDeleted).isFalse())
 				.fetchOne()
 		);
 	}
@@ -46,7 +48,8 @@ public class NoticeRepositoryImpl implements NoticeRepositoryCustom {
 				notice.content
 			))
 			.from(notice)
-			.where(notice.club.id.eq(clubId))
+			.where(notice.club.id.eq(clubId)
+				.and(notice.isDeleted).isFalse())
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
 			.fetch();
@@ -54,7 +57,8 @@ public class NoticeRepositoryImpl implements NoticeRepositoryCustom {
 		Long total = jpaQueryFactory
 			.select(notice.count())
 			.from(notice)
-			.where(notice.club.id.eq(clubId))
+			.where(notice.club.id.eq(clubId)
+				.and(notice.isDeleted).isFalse())
 			.fetchOne();
 
 		return PageResponseDto.toDto(new PageImpl<>(content, pageable, total));

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/notice/repository/NoticeRepositoryImpl.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/notice/repository/NoticeRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.example.cluvrapi.domain.notice.repository;
 import static com.example.cluvrapi.domain.notice.entity.QNotice.notice;
 
 import java.util.List;
+import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
 
@@ -20,19 +21,19 @@ public class NoticeRepositoryImpl implements NoticeRepositoryCustom {
 	private final JPAQueryFactory jpaQueryFactory;
 
 	@Override
-	public InfoNoticeResponseDto findNoticeById(Long clubId, Long noticeId) {
-		InfoNoticeResponseDto content = jpaQueryFactory
-			.select(new QInfoNoticeResponseDto(
-				notice.id,
-				notice.user.id,
-				notice.title,
-				notice.content
-			))
-			.from(notice)
-			.where(notice.id.eq(noticeId).and(notice.club.id.eq(clubId)))
-			.fetchOne();
-
-		return content;
+	public Optional<InfoNoticeResponseDto> findNoticeById(Long clubId, Long noticeId) {
+		return Optional.ofNullable(
+			jpaQueryFactory
+				.select(new QInfoNoticeResponseDto(
+					notice.id,
+					notice.user.id,
+					notice.title,
+					notice.content
+				))
+				.from(notice)
+				.where(notice.id.eq(noticeId).and(notice.club.id.eq(clubId)))
+				.fetchOne()
+		);
 	}
 
 	@Override

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/notice/service/NoticeService.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/notice/service/NoticeService.java
@@ -13,8 +13,6 @@ public interface NoticeService {
 	/**
 	 * 설명: 공지사항을 생성하는 메서드
 	 *
-	 * <p>{}
-	 *
 	 * @param userId                 {설명: 유저 고유 식별자}
 	 * @param clubId                 {설명: 클럽 고유 식별자}
 	 * @param createNoticeRequestDto {설명: Notice 생성 시 필요한 정보}
@@ -27,8 +25,6 @@ public interface NoticeService {
 	/**
 	 * 설명: 공지사항 단건 조회 메서드
 	 *
-	 * <p>{}
-	 *
 	 * @param clubId   {설명: 클럽 고유 식별자}
 	 * @param noticeId {설명: 공지사항 고유 식별자}
 	 * @return InfoNoticeResponseDto {공지사항 정보}
@@ -38,8 +34,6 @@ public interface NoticeService {
 
 	/**
 	 * 설명: 특정 클럽에 대한 모든 공지사항 조회
-	 *
-	 * <p>{}
 	 *
 	 * @param clubId   {설명: 클럽 고유 식별자}
 	 * @param pageable {설명: Pageable 객체}
@@ -51,23 +45,25 @@ public interface NoticeService {
 	/**
 	 * 설명: 공지사항 업데이트하는 메서드
 	 *
-	 * <p>{}
-	 *
+	 * @param userId                 {설명: 유저 고유 식별자}
+	 * @param clubId                 {설명: 클럽 고유 식별자}
 	 * @param noticeId               {설명: 공지사항 고유 식별자}
 	 * @param updateNoticeRequestDto {설명: 공지사항 업데이트할 정보}
 	 * @throws BusinessException {404 NotFound}
 	 * @author {sinyoung0403}
 	 */
-	void updateNotice(Long noticeId, UpdateNoticeRequestDto updateNoticeRequestDto);
+	void updateNotice(Long userId, Long clubId, Long noticeId, UpdateNoticeRequestDto updateNoticeRequestDto);
 
 	/**
 	 * 설명: 공지사항 삭제하는 메서드
 	 *
 	 * <p>{SoftDeleted 적용이 된 상태로 `isDeleted` 열이 true 가 된다.}
 	 *
+	 * @param userId   {설명: 유저 고유 식별자}
+	 * @param clubId   {설명: 클럽 고유 식별자}
 	 * @param noticeId {설명: 공지사항 고유 식별자}
 	 * @throws BusinessException {404 NotFound}
 	 * @author {sinyoung0403}
 	 */
-	void deleteNotice(Long noticeId);
+	void deleteNotice(Long userId, Long clubId, Long noticeId);
 }

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/notice/service/NoticeServiceImpl.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/notice/service/NoticeServiceImpl.java
@@ -69,7 +69,7 @@ public class NoticeServiceImpl implements NoticeService {
 	@Override
 	@Transactional
 	public void updateNotice(Long userId, Long clubId, Long noticeId, UpdateNoticeRequestDto updateNoticeRequestDto) {
-		Notice findNotice = noticeRepository.findByIdOrElseThrow(userId);
+		Notice findNotice = noticeRepository.findByIdOrElseThrow(noticeId);
 
 		ClubMember findClubMember = clubMemberRepository.findByClubIdAndUserId(clubId, userId).orElseThrow(
 			() -> new BusinessException(ResponseCode.INVALID_REQUEST, "해당하는 멤버가 존재하지 않습니다.")

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/notice/service/NoticeServiceImpl.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/notice/service/NoticeServiceImpl.java
@@ -8,7 +8,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.example.cluvrapi.domain.club.entity.Club;
 import com.example.cluvrapi.domain.club.repository.ClubRepository;
+import com.example.cluvrapi.domain.clubMember.entity.ClubMember;
+import com.example.cluvrapi.domain.clubMember.repository.ClubMemberRepository;
 import com.example.cluvrapi.domain.common.dto.PageResponseDto;
+import com.example.cluvrapi.domain.common.validator.ClubValidator;
 import com.example.cluvrapi.domain.notice.dto.reqeust.CreateNoticeRequestDto;
 import com.example.cluvrapi.domain.notice.dto.reqeust.UpdateNoticeRequestDto;
 import com.example.cluvrapi.domain.notice.dto.response.CreateNoticeResponseDto;
@@ -17,6 +20,8 @@ import com.example.cluvrapi.domain.notice.entity.Notice;
 import com.example.cluvrapi.domain.notice.repository.NoticeRepository;
 import com.example.cluvrapi.domain.user.entity.User;
 import com.example.cluvrapi.domain.user.repository.UserRepository;
+import com.example.cluvrapi.global.exception.BusinessException;
+import com.example.cluvrapi.global.response.ResponseCode;
 
 @Service
 @RequiredArgsConstructor
@@ -25,6 +30,8 @@ public class NoticeServiceImpl implements NoticeService {
 	private final UserRepository userRepository;
 	private final ClubRepository clubRepository;
 	private final NoticeRepository noticeRepository;
+	private final ClubMemberRepository clubMemberRepository;
+	private final ClubValidator clubValidator;
 
 	@Override
 	@Transactional
@@ -33,6 +40,11 @@ public class NoticeServiceImpl implements NoticeService {
 		User findUser = userRepository.findByIdOrElseThrow(userId);
 
 		Club findClub = clubRepository.findByIdOrElseThrow(clubId);
+
+		ClubMember findClubMember = clubMemberRepository.findByClubIdAndUserId(clubId, userId).orElseThrow(
+			() -> new BusinessException(ResponseCode.INVALID_REQUEST, "해당하는 멤버가 존재하지 않습니다.")
+		);
+		clubValidator.validateOwnerAndAdminRole(findClubMember.getClubMemberRole());
 
 		Notice notice = new Notice(findUser, findClub, createNoticeRequestDto.getTitle(),
 			createNoticeRequestDto.getContent());
@@ -44,7 +56,9 @@ public class NoticeServiceImpl implements NoticeService {
 
 	@Override
 	public InfoNoticeResponseDto findNoticeById(Long clubId, Long noticeId) {
-		return noticeRepository.findNoticeById(clubId, noticeId);
+		return noticeRepository.findNoticeById(clubId, noticeId).orElseThrow(
+			() -> new BusinessException(ResponseCode.NOT_FOUND, "존재하지 않는 공지사항 입니다.")
+		);
 	}
 
 	@Override
@@ -54,8 +68,13 @@ public class NoticeServiceImpl implements NoticeService {
 
 	@Override
 	@Transactional
-	public void updateNotice(Long noticeId, UpdateNoticeRequestDto updateNoticeRequestDto) {
-		Notice findNotice = noticeRepository.findByIdOrElseThrow(noticeId);
+	public void updateNotice(Long userId, Long clubId, Long noticeId, UpdateNoticeRequestDto updateNoticeRequestDto) {
+		Notice findNotice = noticeRepository.findByIdOrElseThrow(userId);
+
+		ClubMember findClubMember = clubMemberRepository.findByClubIdAndUserId(clubId, userId).orElseThrow(
+			() -> new BusinessException(ResponseCode.INVALID_REQUEST, "해당하는 멤버가 존재하지 않습니다.")
+		);
+		clubValidator.validateOwnerAndAdminRole(findClubMember.getClubMemberRole());
 
 		if (updateNoticeRequestDto.getTitle() != null) {
 			findNotice.updateTitle(updateNoticeRequestDto.getTitle());
@@ -68,7 +87,12 @@ public class NoticeServiceImpl implements NoticeService {
 
 	@Override
 	@Transactional
-	public void deleteNotice(Long noticeId) {
+	public void deleteNotice(Long userId, Long clubId, Long noticeId) {
+		ClubMember findClubMember = clubMemberRepository.findByClubIdAndUserId(clubId, userId).orElseThrow(
+			() -> new BusinessException(ResponseCode.INVALID_REQUEST, "해당하는 멤버가 존재하지 않습니다.")
+		);
+		clubValidator.validateOwnerAndAdminRole(findClubMember.getClubMemberRole());
+
 		Notice findNotice = noticeRepository.findByIdOrElseThrow(noticeId);
 
 		noticeRepository.delete(findNotice);

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/til/controller/TilController.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/til/controller/TilController.java
@@ -72,7 +72,7 @@ public class TilController {
 	}
 
 	@DeleteMapping("/{tilId}")
-	public ResponseEntity<BaseResponse<Void>> updateTil(
+	public ResponseEntity<BaseResponse<Void>> deleteTil(
 		@Auth AuthUser authUser,
 		@PathVariable Long clubId,
 		@PathVariable Long tilId

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/til/controller/TilController.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/til/controller/TilController.java
@@ -16,6 +16,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.example.cluvrapi.domain.common.annotation.Auth;
+import com.example.cluvrapi.domain.common.dto.AuthUser;
 import com.example.cluvrapi.domain.common.dto.PageResponseDto;
 import com.example.cluvrapi.domain.til.dto.reqeust.CreateTilRequestDto;
 import com.example.cluvrapi.domain.til.dto.reqeust.UpdateTilRequestDto;
@@ -34,10 +36,11 @@ public class TilController {
 
 	@PostMapping
 	public ResponseEntity<BaseResponse<CreateTilResponseDto>> createTil(
+		@Auth AuthUser authUser,
 		@PathVariable Long clubId,
 		@Valid @RequestBody CreateTilRequestDto createTilRequestDto
 	) {
-		CreateTilResponseDto createTilResponseDto = tilService.createTil(1L, clubId, createTilRequestDto);
+		CreateTilResponseDto createTilResponseDto = tilService.createTil(authUser.id(), clubId, createTilRequestDto);
 		return ResponseEntity.ok(BaseResponse.success(createTilResponseDto, ResponseCode.CREATED));
 	}
 
@@ -60,18 +63,21 @@ public class TilController {
 
 	@PatchMapping("/{tilId}")
 	public ResponseEntity<BaseResponse<Void>> updateTil(
+		@Auth AuthUser authUser,
 		@PathVariable Long tilId,
 		@Valid @RequestBody UpdateTilRequestDto updateTilRequestDto
 	) {
-		tilService.updateTil(tilId, updateTilRequestDto);
+		tilService.updateTil(authUser.id(), tilId, updateTilRequestDto);
 		return ResponseEntity.ok(BaseResponse.success(ResponseCode.NO_CONTENT));
 	}
 
 	@DeleteMapping("/{tilId}")
 	public ResponseEntity<BaseResponse<Void>> updateTil(
+		@Auth AuthUser authUser,
+		@PathVariable Long clubId,
 		@PathVariable Long tilId
 	) {
-		tilService.deleteTil(tilId);
+		tilService.deleteTil(authUser.id(), clubId, tilId);
 		return ResponseEntity.ok(BaseResponse.success(ResponseCode.NO_CONTENT));
 	}
 }

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/til/repository/TilRepositoryImpl.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/til/repository/TilRepositoryImpl.java
@@ -28,7 +28,7 @@ public class TilRepositoryImpl implements TilRepositoryCustom {
 				til.title,        // title 제목
 				til.content))    // content 내용
 			.from(til)
-			.where(til.id.eq(tilId))
+			.where(til.id.eq(tilId).and(til.isDeleted.isFalse()))
 			.fetchOne();
 		return content;
 	}
@@ -42,7 +42,7 @@ public class TilRepositoryImpl implements TilRepositoryCustom {
 				til.title,        // title 제목
 				til.content))    // content 내용
 			.from(til)
-			.where(til.club.id.eq(clubId))
+			.where(til.club.id.eq(clubId).and(til.isDeleted.isFalse()))
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
 			.fetch();
@@ -50,7 +50,7 @@ public class TilRepositoryImpl implements TilRepositoryCustom {
 		Long total = jpaQueryFactory
 			.select(til.count())
 			.from(til)
-			.where(til.club.id.eq(clubId))
+			.where(til.club.id.eq(clubId).and(til.isDeleted.isFalse()))
 			.fetchOne();
 
 		return PageResponseDto.toDto(new PageImpl<>(content, pageable, total));

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/til/service/TilService.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/til/service/TilService.java
@@ -50,6 +50,7 @@ public interface TilService {
 	 *
 	 * <p> 값이 없을 시, 업데이트하지 않는다.
 	 *
+	 * @param userId              {설명: 유저 고유 식별자}
 	 * @param tilId               {설명: Til 고유 식별자}
 	 * @param updateTilRequestDto {설명: 클럽 업데이트시 필요한 정보}
 	 * @return
@@ -57,15 +58,16 @@ public interface TilService {
 	 * @author {sinyoung0403}
 	 */
 
-	void updateTil(Long tilId, UpdateTilRequestDto updateTilRequestDto);
+	void updateTil(Long userId, Long tilId, UpdateTilRequestDto updateTilRequestDto);
 
 	/**
 	 * 설명: Til 삭제하는 메서드
 	 *
-	 * @param tilId {설명: Til 고유 식별자}
+	 * @param userId {설명: 유저 고유 식별자}
+	 * @param tilId  {설명: Til 고유 식별자}
 	 * @return
 	 * @throws BusinessException {404 NotFound}
 	 * @author {sinyoung0403}
 	 */
-	void deleteTil(Long tilId);
+	void deleteTil(Long userId, Long clubId, Long tilId);
 }

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/til/service/TilServiceImpl.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/til/service/TilServiceImpl.java
@@ -98,7 +98,7 @@ public class TilServiceImpl implements TilService {
 		Til findTil = tilRepository.findByIdOrElseThrow(tilId);
 
 		// 2) 권한 검증. 작성자만 수정 가능하다.
-		if (findTil.getUser().getId().equals(userId)) {
+		if (!findTil.getUser().getId().equals(userId)) {
 			throw new BusinessException(ResponseCode.ACCESS_DENIED, "작성자만 수정 가능합니다.");
 		}
 

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/til/service/TilServiceImpl.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/til/service/TilServiceImpl.java
@@ -118,10 +118,10 @@ public class TilServiceImpl implements TilService {
 	public void deleteTil(Long userId, Long clubId, Long tilId) {
 		// 1) Til 조회, Club 조회
 		Til findTil = tilRepository.findByIdOrElseThrow(tilId);
-		Club findClub = clubRepository.findByIdOrElseThrow(clubId);
+		clubRepository.findByIdOrElseThrow(clubId);
 
 		// 2) 멤버 조회
-		ClubMember clubMember = clubMemberRepository.findOwnerByClub(findClub).orElseThrow(
+		ClubMember clubMember = clubMemberRepository.findByClubIdAndUserId(clubId, userId).orElseThrow(
 			() -> new BusinessException(ResponseCode.INVALID_REQUEST)
 		);
 

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/til/service/TilServiceImpl.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/til/service/TilServiceImpl.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.example.cluvrapi.domain.club.entity.Club;
 import com.example.cluvrapi.domain.club.repository.ClubRepository;
 import com.example.cluvrapi.domain.clubMember.entity.ClubMember;
+import com.example.cluvrapi.domain.clubMember.entity.enums.ClubMemberRole;
 import com.example.cluvrapi.domain.clubMember.repository.ClubMemberRepository;
 import com.example.cluvrapi.domain.common.dto.PageResponseDto;
 import com.example.cluvrapi.domain.notification.enums.NotiTargetType;
@@ -42,8 +43,9 @@ public class TilServiceImpl implements TilService {
 		// 1) 유저 및 클럽 조회
 		User findUser = userRepository.findByIdOrElseThrow(userId);
 		Club findClub = clubRepository.findByIdOrElseThrow(clubId);
-		ClubMember clubMember = clubMemberRepository.findOwnerByClub(findClub).orElseThrow(
-			() -> new BusinessException(ResponseCode.INVALID_REQUEST)
+
+		ClubMember clubMember = clubMemberRepository.findByClubIdAndUserId(clubId, userId).orElseThrow(
+			() -> new BusinessException(ResponseCode.ACCESS_DENIED, "해당 클랜의 멤버가 아닙니다.")
 		);
 
 		// 2) Til Entity 생성
@@ -91,9 +93,14 @@ public class TilServiceImpl implements TilService {
 
 	@Override
 	@Transactional
-	public void updateTil(Long tilId, UpdateTilRequestDto updateTilRequestDto) {
+	public void updateTil(Long userId, Long tilId, UpdateTilRequestDto updateTilRequestDto) {
 		// 1) Til 조회
 		Til findTil = tilRepository.findByIdOrElseThrow(tilId);
+
+		// 2) 권한 검증. 작성자만 수정 가능하다.
+		if (findTil.getUser().getId().equals(userId)) {
+			throw new BusinessException(ResponseCode.ACCESS_DENIED, "작성자만 수정 가능합니다.");
+		}
 
 		// 2) 제목 업데이트
 		if (updateTilRequestDto.getTitle() != null) {
@@ -108,11 +115,25 @@ public class TilServiceImpl implements TilService {
 
 	@Override
 	@Transactional
-	public void deleteTil(Long tilId) {
-		// 1) Til 조회
+	public void deleteTil(Long userId, Long clubId, Long tilId) {
+		// 1) Til 조회, Club 조회
 		Til findTil = tilRepository.findByIdOrElseThrow(tilId);
+		Club findClub = clubRepository.findByIdOrElseThrow(clubId);
 
-		// 2) Til 삭제
+		// 2) 멤버 조회
+		ClubMember clubMember = clubMemberRepository.findOwnerByClub(findClub).orElseThrow(
+			() -> new BusinessException(ResponseCode.INVALID_REQUEST)
+		);
+
+		// 3) 권한 검증. 작성자와 클랜 관리자만 삭제 가능하다.
+		if (!findTil.getUser().getId().equals(userId)
+			&& clubMember.getClubMemberRole() != ClubMemberRole.OWNER
+			&& clubMember.getClubMemberRole() != ClubMemberRole.ADMIN
+		) {
+			throw new BusinessException(ResponseCode.ACCESS_DENIED, "작성자와 클랜 관리자만이 삭제 가능합니다.");
+		}
+
+		// 3) Til 삭제
 		tilRepository.delete(findTil);
 	}
 }


### PR DESCRIPTION
<!-- 
꼭 제목을 아래와 같은 형식으로 변경해주세요 !
Feat/#24:board-crud

: <- 이거 잊으시면 안 됩니다!
-->

## 📌 개요

<!-- 어떤 작업을 했는지 한 줄로 요약해주세요. -->
권한 검증을 추가했습니다.

---

## 🔍 관련 이슈

<!-- 연결된 이슈가 있다면 닫히도록 설정해주세요. -->

- Closes #93

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 문제 폼의 활성화 상태를 조회하고 변경할 수 있는 엔드포인트가 추가되었습니다.
  - 클럽과 제출 폼 간 1:1 연관관계가 도입되었습니다.

- **버그 수정**
  - 엔티티 조회 실패 시 명확한 예외 처리 및 안내 메시지가 추가되었습니다.

- **개선사항**
  - 문제 폼, 제출 폼, 공지, TIL(오늘 배운 것) 작성·수정·삭제 시 인증된 사용자만 접근할 수 있도록 인증 및 권한 검증이 강화되었습니다.
  - 폼 생성, 수정, 삭제 등 주요 변경 작업에 대해 사용자 권한 및 역할(OWNER, ADMIN 등) 검증 로직이 추가되었습니다.
  - 응답 코드 및 반환값이 RESTful 표준에 맞게 개선되었습니다.
  - 일부 조회 API에서 결과가 없을 경우 명확하게 Optional로 반환하도록 개선되었습니다.
  - TIL, 공지, 제출 폼, 문제 폼 관련 삭제 시 연관 데이터 처리 및 권한 검증이 강화되었습니다.
  - 이슈 템플릿의 라벨명이 이모지 포함된 시각적으로 구분되는 형태로 변경되었습니다.
  - 삭제된 데이터는 조회에서 제외되도록 필터링이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->