### PR TITLE
Feat/#106:securityrefactor

### DIFF
--- a/cluvr-api/build.gradle
+++ b/cluvr-api/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.5.0'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'org.jetbrains.kotlin.jvm'
 }
 
 // Q클래스 파일 경로 설정
@@ -90,6 +91,7 @@ dependencies {
     // prometheus
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 }
 
 tasks.named('test') {

--- a/cluvr-api/build.gradle
+++ b/cluvr-api/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.5.0'
     id 'io.spring.dependency-management' version '1.1.7'
-    id 'org.jetbrains.kotlin.jvm'
 }
 
 // Q클래스 파일 경로 설정
@@ -91,7 +90,6 @@ dependencies {
     // prometheus
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 }
 
 tasks.named('test') {

--- a/cluvr-api/src/main/java/com/example/cluvrapi/CluvrApiApplication.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/CluvrApiApplication.java
@@ -3,9 +3,11 @@ package com.example.cluvrapi;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 
 @EnableJpaAuditing
 @SpringBootApplication
+@EnableMethodSecurity(prePostEnabled = true)
 public class CluvrApiApplication {
 
     public static void main(String[] args) {

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/auth/properties/AppProperties.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/auth/properties/AppProperties.java
@@ -1,0 +1,15 @@
+package com.example.cluvrapi.domain.auth.properties;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "app")
+public class AppProperties {
+	private List<String> adminDomains = new ArrayList<>();
+	public List<String> getAdminDomains() { return adminDomains; }
+	public void setAdminDomains(List<String> domains) { this.adminDomains = domains; }
+}

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/auth/service/AuthServiceImpl.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/auth/service/AuthServiceImpl.java
@@ -14,6 +14,7 @@ import com.example.cluvrapi.domain.auth.dto.request.LoginUserRequestDto;
 import com.example.cluvrapi.domain.auth.dto.request.SignUpUserRequestDto;
 import com.example.cluvrapi.domain.auth.dto.response.LoginUserResponseDto;
 import com.example.cluvrapi.domain.auth.dto.response.SignUpUserResponseDto;
+import com.example.cluvrapi.domain.auth.properties.AppProperties;
 import com.example.cluvrapi.domain.category.entity.Category;
 import com.example.cluvrapi.domain.category.enums.CategoryTargetType;
 import com.example.cluvrapi.domain.category.repository.CategoryRepository;
@@ -39,10 +40,12 @@ public class AuthServiceImpl implements AuthService {
 	private final RefreshTokenServiceImpl refreshTokenService;
 	private final CategoryRepository categoryRepository;
 	private final CloverService cloverService;
+	private final AppProperties appProperties;
 
 	@Override
 	@Transactional
 	public SignUpUserResponseDto signUp(SignUpUserRequestDto requestDto) {
+
 
 		if (userRepository.existsByEmail(requestDto.getEmail())) {
 			throw new BusinessException(
@@ -50,7 +53,6 @@ public class AuthServiceImpl implements AuthService {
 				"이미 사용 중인 이메일입니다."
 			);
 		}
-
 		if (userRepository.existsByPhoneNumber(requestDto.getPhoneNumber())) {
 			throw new BusinessException(
 				ResponseCode.INVALID_REQUEST,
@@ -64,31 +66,42 @@ public class AuthServiceImpl implements AuthService {
 			);
 		}
 
+		String email = requestDto.getEmail().toLowerCase();
+		String domain = email.substring(email.indexOf("@") + 1);
+
+		UserRole assignedRole = appProperties.getAdminDomains().contains(domain)
+			? UserRole.ADMIN
+			: UserRole.USER;
+
 		String encodedPassword = passwordEncoder.encode(requestDto.getPassword());
 
-		User newUser = new User(null,                                      // id → 데이터베이스에서 자동 생성
-			requestDto.getName(),                      // name
-			requestDto.getBirthday(),                  // birthday
-			requestDto.getEmail(),                     // email
-			requestDto.getPhoneNumber(),               // phoneNumber
-			UserRole.USER,                             // 가입 시 기본 권한(예: USER)
-			requestDto.getGender(),                    // gender
+		User newUser = new User(
+			null,                                    // id auto-generated
+			requestDto.getName(),                    // name
+			requestDto.getBirthday(),                // birthday
+			email,                                   // email (소문자)
+			requestDto.getPhoneNumber(),             // phoneNumber
+			assignedRole,                            // UserRole: USER or ADMIN
+			requestDto.getGender(),                  // gender
 			requestDto.getCategoryType(),            // categoryDetail
-			encodedPassword,                           // 암호화된 password
-			0,                                        // gem 기본값
-			requestDto.getImageUrl(),                  // imageUrl (null 허용될 경우 DTO에서 null 가능)
-			false                                      // isDeleted: 신규 가입이므로 false
+			encodedPassword,                         // encrypted password
+			0,                                       // gem 기본값
+			requestDto.getImageUrl(),                // imageUrl
+			false                                    // isDeleted
 		);
 
 		User savedUser = userRepository.save(newUser);
 
-		// 5) Category 엔티티 생성 및 저장 (유저용)
-		Category newCategory = new Category(savedUser.getId(),                // targetId = 유저 ID
-			requestDto.getCategoryType(),     // CategoryType (예: DEVELOPMENT, MUSIC_EDUCATION 등)
-			CategoryTargetType.USER           // targetType = USER
+		// 6) Category, Clover 등 기존 로직 유지
+		Category newCategory = new Category(
+			savedUser.getId(),
+			requestDto.getCategoryType(),
+			CategoryTargetType.USER
 		);
 		categoryRepository.save(newCategory);
-		cloverService.createClover(CreateCloverRequestDto.from(0, Tier.SPROUT, savedUser.getId()));
+		cloverService.createClover(
+			CreateCloverRequestDto.from(0, Tier.SPROUT, savedUser.getId())
+		);
 
 		return SignUpUserResponseDto.from(savedUser);
 	}

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/clubMember/controller/ClubMemberController.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/clubMember/controller/ClubMemberController.java
@@ -60,26 +60,34 @@ public class ClubMemberController {
 	}
 
 	@DeleteMapping("/members/me")
-	public ResponseEntity<BaseResponse<Void>> withdrawFromClub(
+	public ResponseEntity<BaseResponse<String>> withdrawFromClub(
 		@PathVariable Long clubId,
 		@Auth AuthUser authUser
 	) {
 		clubMemberService.withdrawFromClub(clubId, authUser);
 		return ResponseEntity
-			.status(HttpStatus.NO_CONTENT)
-			.body(BaseResponse.success(ResponseCode.NO_CONTENT));
+			.ok(
+				BaseResponse.success(
+					"클럽 탈퇴가 완료되었습니다.",
+					ResponseCode.OK
+				)
+			);
 	}
 
 	@DeleteMapping("/members/{memberId}")
-	public ResponseEntity<BaseResponse<Void>> kickMember(
+	public ResponseEntity<BaseResponse<String>> kickMember(
 		@PathVariable Long clubId,
 		@PathVariable Long memberId,
 		@Auth AuthUser authUser
 	) {
 		clubMemberService.kickMember(clubId, authUser, memberId);
 		return ResponseEntity
-			.status(HttpStatus.NO_CONTENT)
-			.body(BaseResponse.success(ResponseCode.NO_CONTENT));
+			.ok(
+				BaseResponse.success(
+					"멤버 강퇴가 완료되었습니다.",
+					ResponseCode.OK
+				)
+			);
 	}
 
 	@GetMapping("/members")

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/clubMember/controller/ClubMemberController.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/clubMember/controller/ClubMemberController.java
@@ -104,4 +104,15 @@ public class ClubMemberController {
 			.ok(BaseResponse.success(dto, ResponseCode.OK));
 	}
 
+	@PostMapping("/{targetMemberId}/transfer-owner")
+
+	public BaseResponse<Void> transferOwner(
+		@PathVariable Long clubId,
+		@PathVariable Long targetMemberId,
+		@Auth AuthUser authUser
+	) {
+		clubMemberService.changeOwnership(clubId, authUser, targetMemberId);
+		return BaseResponse.success(null, ResponseCode.OK);
+	}
+
 }

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/clubMember/controller/ClubMemberController.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/clubMember/controller/ClubMemberController.java
@@ -114,13 +114,14 @@ public class ClubMemberController {
 
 	@PostMapping("/{targetMemberId}/transfer-owner")
 
-	public BaseResponse<Void> transferOwner(
+	public ResponseEntity<BaseResponse<Void>> transferOwner(
 		@PathVariable Long clubId,
 		@PathVariable Long targetMemberId,
 		@Auth AuthUser authUser
 	) {
 		clubMemberService.changeOwnership(clubId, authUser, targetMemberId);
-		return BaseResponse.success(null, ResponseCode.OK);
+		return ResponseEntity.ok(BaseResponse.success(ResponseCode.OK));
+
 	}
 
 }

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/clubMember/service/ClubMemberService.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/clubMember/service/ClubMemberService.java
@@ -8,6 +8,9 @@ import com.example.cluvrapi.domain.clubMember.dto.response.GetMemberRoleResponse
 import com.example.cluvrapi.domain.clubMember.entity.enums.ClubMemberRole;
 import com.example.cluvrapi.domain.common.dto.AuthUser;
 import com.example.cluvrapi.domain.join.enums.JoinStatus;
+import com.example.cluvrapi.global.annotation.IsClubAdmin;
+import com.example.cluvrapi.global.annotation.IsClubMember;
+import com.example.cluvrapi.global.annotation.IsClubOwner;
 
 import jakarta.validation.constraints.NotNull;
 
@@ -31,6 +34,7 @@ public interface ClubMemberService {
 	 * @param approver      설명: 요청을 승인/거절하는 운영자 정보
 	 * @throws BusinessException 설명: 요청이 존재하지 않거나 권한이 없을 경우 발생
 	 */
+	@IsClubAdmin
 	void handleJoinRequest(Long clubId, Long joinRequestId, JoinStatus status, AuthUser approver);
 
 	/**
@@ -44,6 +48,7 @@ public interface ClubMemberService {
 	 * @param newRole      설명: 설정할 새로운 역할(ClubMemberRole)
 	 * @throws BusinessException 설명: 권한이 없거나 대상 멤버가 존재하지 않을 경우 발생
 	 */
+	@IsClubAdmin
 	void changeMemberRole(Long clubId, AuthUser operator, Long targetUserId,
 		@NotNull(message = "변경할 역할을 지정하세요.") ClubMemberRole newRole);
 
@@ -56,6 +61,7 @@ public interface ClubMemberService {
 	 * @param user   설명: 탈퇴 요청을 수행하는 사용자 정보
 	 * @throws BusinessException 설명: 클럽 또는 멤버가 존재하지 않거나 상태가 올바르지 않을 경우 발생
 	 */
+	@IsClubMember
 	void withdrawFromClub(Long clubId, AuthUser user);
 
 	/**
@@ -68,6 +74,7 @@ public interface ClubMemberService {
 	 * @param targetMemberId 설명: 추방할 대상 멤버의 사용자 식별자
 	 * @throws BusinessException 설명: 권한이 없거나 대상 멤버가 존재하지 않을 경우 발생
 	 */
+	@IsClubAdmin
 	void kickMember(Long clubId, AuthUser operator, Long targetMemberId);
 
 	/**
@@ -81,6 +88,7 @@ public interface ClubMemberService {
 	 * @return Page<ClubMemberInfoResponseDto> 설명: 조회된 클럽 멤버 정보가 담긴 페이징 결과
 	 * @throws BusinessException 설명: 권한이 없거나 클럽이 존재하지 않을 경우 발생
 	 */
+	@IsClubMember
 	Page<ClubMemberInfoResponseDto> listMembers(Long clubId, AuthUser authUser, Pageable pageable);
 
 	/**
@@ -94,4 +102,7 @@ public interface ClubMemberService {
 	 * @throws BusinessException 설명: 클럽 또는 대상 멤버가 존재하지 않을 경우 발생
 	 */
 	GetMemberRoleResponseDto getMemberRole(Long clubId, Long targetUserId);
+
+	@IsClubOwner
+	void changeOwnership(Long clubId, AuthUser requestUser, Long targetMemberId);
 }

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/clubMember/service/ClubMemberServiceImpl.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/clubMember/service/ClubMemberServiceImpl.java
@@ -21,6 +21,9 @@ import com.example.cluvrapi.domain.common.dto.AuthUser;
 import com.example.cluvrapi.domain.join.entity.JoinRequest;
 import com.example.cluvrapi.domain.join.enums.JoinStatus;
 import com.example.cluvrapi.domain.join.repository.JoinRequestRepository;
+import com.example.cluvrapi.global.annotation.IsClubAdmin;
+import com.example.cluvrapi.global.annotation.IsClubMember;
+import com.example.cluvrapi.global.annotation.IsClubOwner;
 import com.example.cluvrapi.global.exception.BusinessException;
 import com.example.cluvrapi.global.response.ResponseCode;
 
@@ -40,13 +43,6 @@ public class ClubMemberServiceImpl implements ClubMemberService {
 
 		if (jr.getJoinStatus() != JoinStatus.PENDING) {
 			throw new BusinessException(ResponseCode.INVALID_REQUEST, "이미 처리된 요청입니다.");
-		}
-
-		ClubMember approverMember = clubMemberRepository.findByClubIdAndUserId(clubId, approver.id())
-			.orElseThrow(() -> new BusinessException(ResponseCode.INVALID_REQUEST, "권한이 없습니다."));
-		if (approverMember.getClubMemberRole() != ClubMemberRole.OWNER
-			&& approverMember.getClubMemberRole() != ClubMemberRole.ADMIN) {
-			throw new BusinessException(ResponseCode.INVALID_REQUEST, "승인 권한이 없습니다.");
 		}
 
 		Club club = jr.getClub();
@@ -84,43 +80,48 @@ public class ClubMemberServiceImpl implements ClubMemberService {
 		}
 	}
 
+
 	@Override
 	@Transactional
-	public void changeMemberRole(Long clubId, AuthUser authUser, Long targetMemberId, ClubMemberRole newRole) {
+	public void changeMemberRole(Long clubId,
+		AuthUser authUser,
+		Long targetMemberId,
+		ClubMemberRole newRole) {
+		// OWNER 위임은 별도 API(/transfer-owner)로만 허용
+		if (newRole == ClubMemberRole.OWNER) {
+			throw new BusinessException(
+				ResponseCode.INVALID_REQUEST,
+				"OWNER 권한 변경은 transferOwner API를 이용하세요."
+			);
+		}
+
 		Club club = clubRepository.findByIdOrElseThrow(clubId);
 
-		Long operatorUserId = authUser.id();
-
-		// operator(요청자)의 ClubMember 엔티티 조회
-		ClubMember operatorMember = clubMemberRepository.findByClubIdAndUserId(clubId, operatorUserId)
-			.orElseThrow(() -> new BusinessException(ResponseCode.INVALID_REQUEST, "권한이 없습니다."));
+		// 현재 소유자 조회 (ADMIN은 OWNER 전환 자체가 차단되므로 이 라인은 OWNER 전환이 아닐 때만 사용)
+		ClubMember currentOwner = clubMemberRepository.findOwnerByClub(club)
+			.orElseThrow(() -> new BusinessException(
+				ResponseCode.NOT_FOUND,
+				"OWNER 정보가 없습니다."
+			));
 
 		ClubMember target = clubMemberRepository.findById(targetMemberId)
 			.filter(cm -> cm.getClub().getId().equals(clubId))
-			.orElseThrow(() -> new BusinessException(ResponseCode.NOT_FOUND, "대상 멤버를 찾을 수 없습니다."));
+			.orElseThrow(() -> new BusinessException(
+				ResponseCode.NOT_FOUND,
+				"대상 멤버를 찾을 수 없습니다."
+			));
 
-		if (newRole == ClubMemberRole.OWNER) {
-			if (operatorMember.getClubMemberRole() != ClubMemberRole.OWNER) {
-				throw new BusinessException(ResponseCode.INVALID_REQUEST, "OWNER 권한이 필요합니다.");
-			}
-			ClubMember currentOwner = clubMemberRepository.findOwnerByClub(club)
-				.orElseThrow(() -> new BusinessException(ResponseCode.NOT_FOUND, "OWNER 정보가 없습니다."));
-			currentOwner.changeRole(ClubMemberRole.ADMIN);
-
-			target.changeRole(ClubMemberRole.OWNER);
-
-		} else {
-			if (!(operatorMember.getClubMemberRole() == ClubMemberRole.OWNER
-				|| operatorMember.getClubMemberRole() == ClubMemberRole.ADMIN)) {
-				throw new BusinessException(ResponseCode.INVALID_REQUEST, "권한이 없습니다.");
-			}
-			if (operatorMember.getClubMemberRole() == ClubMemberRole.ADMIN && newRole == ClubMemberRole.ADMIN) {
-				throw new BusinessException(ResponseCode.INVALID_REQUEST, "ADMIN은 ADMIN으로 변경할 수 없습니다.");
-			}
-			target.changeRole(newRole);
+		// ADMIN은 ADMIN으로 변경 불가
+		if (currentOwner.getClubMemberRole() == ClubMemberRole.ADMIN
+			&& newRole == ClubMemberRole.ADMIN) {
+			throw new BusinessException(
+				ResponseCode.INVALID_REQUEST,
+				"ADMIN은 ADMIN으로 변경할 수 없습니다."
+			);
 		}
-	}
 
+		target.changeRole(newRole);
+	}
 	@Override
 	@Transactional
 	public void withdrawFromClub(Long clubId, AuthUser user) {
@@ -135,11 +136,6 @@ public class ClubMemberServiceImpl implements ClubMemberService {
 	@Override
 	@Transactional
 	public void kickMember(Long clubId, AuthUser operator, Long targetMemberId) {
-		ClubMember op = clubMemberRepository.findByClubIdAndUserId(clubId, operator.id())
-			.orElseThrow(() -> new BusinessException(ResponseCode.INVALID_REQUEST, "권한이 없습니다."));
-		if (op.getClubMemberRole() != ClubMemberRole.OWNER && op.getClubMemberRole() != ClubMemberRole.ADMIN) {
-			throw new BusinessException(ResponseCode.INVALID_REQUEST, "ADMIN 이상만 강퇴할 수 있습니다.");
-		}
 
 		ClubMember target = clubMemberRepository.findById(targetMemberId)
 			.filter(cm -> cm.getClub().getId().equals(clubId))
@@ -155,13 +151,6 @@ public class ClubMemberServiceImpl implements ClubMemberService {
 	@Transactional(readOnly = true)
 	public Page<ClubMemberInfoResponseDto> listMembers(Long clubId, AuthUser authUser, Pageable pageable) {
 
-		boolean isMember = clubMemberRepository.findByClubIdAndUserId(clubId, authUser.id())
-			.filter(cm -> cm.getClubMemberStatus() == ClubMemberStatus.ACTIVE)
-			.isPresent();
-
-		if (!isMember) {
-			throw new BusinessException(ResponseCode.INVALID_REQUEST, "클럽의 ACTIVE 멤버만 조회할 수 있습니다.");
-		}
 
 		Page<ClubMember> page = clubMemberRepository.findActiveMembersByClubId(clubId, pageable);
 
@@ -184,5 +173,28 @@ public class ClubMemberServiceImpl implements ClubMemberService {
 		);
 	}
 
+	@Override
+	@Transactional
+	public void changeOwnership(Long clubId, AuthUser requestUser, Long targetMemberId) {
+		Club club = clubRepository.findByIdOrElseThrow(clubId);
+
+		ClubMember currentOwner = clubMemberRepository.findOwnerByClub(club)
+			.orElseThrow(() -> new BusinessException(ResponseCode.NOT_FOUND, "현재 OWNER 정보가 없습니다."));
+
+		ClubMember target = clubMemberRepository.findById(targetMemberId)
+			.filter(cm -> cm.getClub().getId().equals(clubId))
+			.orElseThrow(() -> new BusinessException(ResponseCode.NOT_FOUND, "위임할 멤버를 찾을 수 없습니다."));
+
+		if (target.getClubMemberStatus() != ClubMemberStatus.ACTIVE ||
+			target.getClubMemberRole() != ClubMemberRole.MEMBER) {
+			throw new BusinessException(
+				ResponseCode.INVALID_REQUEST,
+				"ACTIVE MEMBER만 OWNER로 위임할 수 있습니다."
+			);
+		}
+
+		currentOwner.changeRole(ClubMemberRole.ADMIN);
+		target.changeRole(ClubMemberRole.OWNER);
+	}
 }
 

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/user/controller/UserController.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/user/controller/UserController.java
@@ -71,11 +71,15 @@ public class UserController {
 	}
 
 	@DeleteMapping("/me")
-	public ResponseEntity<BaseResponse<Void>> deleteMyProfile(@Auth AuthUser authUser) {
+	public ResponseEntity<BaseResponse<String>> deleteMyProfile(@Auth AuthUser authUser) {
 		userService.deleteMyProfile(authUser.id());
 		return ResponseEntity
-			.status(HttpStatus.NO_CONTENT)
-			.body(BaseResponse.success(ResponseCode.NO_CONTENT));
+			.ok(
+				BaseResponse.success(
+					"회원 탈퇴가 완료되었습니다.",
+					ResponseCode.OK
+				)
+			);
 	}
 
 }

--- a/cluvr-api/src/main/java/com/example/cluvrapi/global/annotation/IsClubAdmin.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/global/annotation/IsClubAdmin.java
@@ -1,0 +1,14 @@
+package com.example.cluvrapi.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@PreAuthorize("@clubSec.isAdmin(#clubId)")
+public @interface IsClubAdmin {
+}

--- a/cluvr-api/src/main/java/com/example/cluvrapi/global/annotation/IsClubMember.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/global/annotation/IsClubMember.java
@@ -1,0 +1,14 @@
+package com.example.cluvrapi.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@PreAuthorize("@clubSec.isMember(#clubId)")
+public @interface IsClubMember {
+}

--- a/cluvr-api/src/main/java/com/example/cluvrapi/global/annotation/IsClubOwner.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/global/annotation/IsClubOwner.java
@@ -1,0 +1,14 @@
+package com.example.cluvrapi.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@PreAuthorize("@ClubSec.isOwner(#clubId)")
+public @interface IsClubOwner {
+}

--- a/cluvr-api/src/main/java/com/example/cluvrapi/global/config/SecurityConfig.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/global/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.example.cluvrapi.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -11,7 +12,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-import com.example.cluvrapi.domain.user.repository.UserRepository;
 import com.example.cluvrapi.global.jwt.CustomUserDetailsService;
 import com.example.cluvrapi.global.jwt.JwtAuthenticationFilter;
 import com.example.cluvrapi.global.jwt.JwtUtil;
@@ -20,21 +20,19 @@ import com.example.cluvrapi.global.jwt.RefreshTokenService;
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
-	private final CustomUserDetailsService customUserDetailsService;
+
+	private final CustomUserDetailsService userDetailsService;
 	private final JwtUtil jwtUtil;
-	private final UserRepository userRepository;
 	private final RefreshTokenService refreshTokenService;
 
 	public SecurityConfig(
-		CustomUserDetailsService customUserDetailsService,
+		CustomUserDetailsService userDetailsService,
 		JwtUtil jwtUtil,
-		UserRepository userRepository,
 		RefreshTokenService refreshTokenService
 	) {
-		this.customUserDetailsService = customUserDetailsService;         // ← 추가
-		this.jwtUtil = jwtUtil;                                           // ← 추가
-		this.userRepository = userRepository;
-		this.refreshTokenService = refreshTokenService; // ← 추가
+		this.userDetailsService = userDetailsService;
+		this.jwtUtil = jwtUtil;
+		this.refreshTokenService = refreshTokenService;
 	}
 
 	@Bean
@@ -51,8 +49,38 @@ public class SecurityConfig {
 	}
 
 	@Bean
+	@Order(1)
+	public SecurityFilterChain clubChain(HttpSecurity http, CustomUserDetailsService userDetailsService) throws Exception {
+		http
+			.securityMatcher("/api/clubs/**")
+			.csrf(csrf -> csrf.disable())
+			.formLogin(form -> form.disable())
+			.httpBasic(basic -> basic.disable())
+			.sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.userDetailsService(userDetailsService)
+			.addFilterBefore(
+				new JwtAuthenticationFilter(jwtUtil, userDetailsService, refreshTokenService),
+				UsernamePasswordAuthenticationFilter.class
+			)
+			.authorizeHttpRequests(auth -> auth
+				// OWNER 기능 (메타 애노테이션으로 실제 제어)
+				.requestMatchers("/api/clubs/{clubId}/settings/**").authenticated()
+				// ADMIN 기능
+				.requestMatchers("/api/clubs/{clubId}/members/**").authenticated()
+				// MEMBER 기능
+				.requestMatchers("/api/clubs/{clubId}/**").authenticated()
+				// 클럽 내/외 공통 ADMIN-only
+				.requestMatchers("/admin/**").hasRole("ADMIN")
+				// 나머지 클럽 URL: 인증만
+				.anyRequest().authenticated()
+			);
 
-	public SecurityFilterChain filterChain(HttpSecurity http) throws
+		return http.build();
+	}
+
+	@Bean
+	@Order(2)
+	public SecurityFilterChain defaultChain(HttpSecurity http) throws
 		Exception {
 
 		http
@@ -62,7 +90,7 @@ public class SecurityConfig {
 			.sessionManagement(sm ->
 				sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 			)
-			.userDetailsService(customUserDetailsService)
+			.userDetailsService(userDetailsService)
 			.authorizeHttpRequests(auth -> auth
 				// 회원가입·로그인만 공개
 				.requestMatchers("/auth/signup", "/auth/login", "/my-monitor/**", "/**").permitAll()
@@ -72,7 +100,7 @@ public class SecurityConfig {
 				.anyRequest().authenticated()
 			)
 			.addFilterBefore(
-				new JwtAuthenticationFilter(jwtUtil, customUserDetailsService, refreshTokenService),
+				new JwtAuthenticationFilter(jwtUtil, userDetailsService, refreshTokenService),
 				UsernamePasswordAuthenticationFilter.class
 			);
 

--- a/cluvr-api/src/main/java/com/example/cluvrapi/global/config/SecurityConfig.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/global/config/SecurityConfig.java
@@ -50,9 +50,10 @@ public class SecurityConfig {
 
 	@Bean
 	@Order(1)
-	public SecurityFilterChain clubChain(HttpSecurity http, CustomUserDetailsService userDetailsService) throws Exception {
+	public SecurityFilterChain clubChain(HttpSecurity http,
+		CustomUserDetailsService userDetailsService) throws Exception {
 		http
-			.securityMatcher("/api/clubs/**")
+			.securityMatcher("/api/clubs/**")  // 이 체인은 이 경로에만 적용
 			.csrf(csrf -> csrf.disable())
 			.formLogin(form -> form.disable())
 			.httpBasic(basic -> basic.disable())
@@ -63,15 +64,6 @@ public class SecurityConfig {
 				UsernamePasswordAuthenticationFilter.class
 			)
 			.authorizeHttpRequests(auth -> auth
-				// OWNER 기능 (메타 애노테이션으로 실제 제어)
-				.requestMatchers("/api/clubs/{clubId}/settings/**").authenticated()
-				// ADMIN 기능
-				.requestMatchers("/api/clubs/{clubId}/members/**").authenticated()
-				// MEMBER 기능
-				.requestMatchers("/api/clubs/{clubId}/**").authenticated()
-				// 클럽 내/외 공통 ADMIN-only
-				.requestMatchers("/admin/**").hasRole("ADMIN")
-				// 나머지 클럽 URL: 인증만
 				.anyRequest().authenticated()
 			);
 

--- a/cluvr-api/src/main/java/com/example/cluvrapi/global/security/ClubSecurityService.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/global/security/ClubSecurityService.java
@@ -7,7 +7,9 @@ import org.springframework.stereotype.Component;
 import com.example.cluvrapi.domain.clubMember.entity.enums.ClubMemberRole;
 import com.example.cluvrapi.domain.clubMember.entity.enums.ClubMemberStatus;
 import com.example.cluvrapi.domain.clubMember.repository.ClubMemberRepository;
+import com.example.cluvrapi.global.exception.BusinessException;
 import com.example.cluvrapi.global.jwt.CustomUserDetails;
+import com.example.cluvrapi.global.response.ResponseCode;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,25 +26,50 @@ public class ClubSecurityService {
 	}
 
 	public boolean isMember(Long clubId) {
-		return clubMemberRepository.findByClubIdAndUserId(clubId, currentUserId())
+		var optionalMember = clubMemberRepository.findByClubIdAndUserId(clubId, currentUserId());
+
+		boolean isActiveMember = optionalMember
 			.filter(cm -> cm.getClubMemberStatus() == ClubMemberStatus.ACTIVE)
 			.isPresent();
+
+		if (!isActiveMember) {
+			throw new BusinessException(
+				ResponseCode.ACCESS_DENIED,
+				"해당 클럽의 활성 멤버만 접근할 수 있는 기능입니다."
+			);
+		}
+
+		return true;
 	}
 
 	public boolean isAdmin(Long clubId) {
-		return clubMemberRepository.findByClubIdAndUserId(clubId, currentUserId())
+		boolean admin = clubMemberRepository.findByClubIdAndUserId(clubId, currentUserId())
 			.filter(cm -> cm.getClubMemberStatus() == ClubMemberStatus.ACTIVE)
 			.map(cm -> {
 				ClubMemberRole role = cm.getClubMemberRole();
 				return role == ClubMemberRole.ADMIN || role == ClubMemberRole.OWNER;
 			})
 			.orElse(false);
+		if (!admin) {
+			throw new BusinessException(
+				ResponseCode.ACCESS_DENIED,
+				"클럽 관리자 또는 소유자만 접근할 수 있는 기능입니다."
+			);
+		}
+		return true;
 	}
 
 	public boolean isOwner(Long clubId) {
-		return clubMemberRepository.findByClubIdAndUserId(clubId, currentUserId())
+		boolean owner = clubMemberRepository.findByClubIdAndUserId(clubId, currentUserId())
 			.filter(cm -> cm.getClubMemberStatus() == ClubMemberStatus.ACTIVE)
 			.map(cm -> cm.getClubMemberRole() == ClubMemberRole.OWNER)
 			.orElse(false);
+		if (!owner) {
+			throw new BusinessException(
+				ResponseCode.ACCESS_DENIED,
+				"클럽 소유자만 접근할 수 있는 기능입니다."
+			);
+		}
+		return true;
 	}
 }

--- a/cluvr-api/src/main/java/com/example/cluvrapi/global/security/ClubSecurityService.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/global/security/ClubSecurityService.java
@@ -1,0 +1,48 @@
+package com.example.cluvrapi.global.security;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import com.example.cluvrapi.domain.clubMember.entity.enums.ClubMemberRole;
+import com.example.cluvrapi.domain.clubMember.entity.enums.ClubMemberStatus;
+import com.example.cluvrapi.domain.clubMember.repository.ClubMemberRepository;
+import com.example.cluvrapi.global.jwt.CustomUserDetails;
+
+import lombok.RequiredArgsConstructor;
+
+@Component("clubSec")
+@RequiredArgsConstructor
+public class ClubSecurityService {
+
+	private final ClubMemberRepository clubMemberRepository;
+
+	private Long currentUserId(){
+		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+		CustomUserDetails user = (CustomUserDetails) auth.getPrincipal();
+		return user.getId();
+	}
+
+	public boolean isMember(Long clubId) {
+		return clubMemberRepository.findByClubIdAndUserId(clubId, currentUserId())
+			.filter(cm -> cm.getClubMemberStatus() == ClubMemberStatus.ACTIVE)
+			.isPresent();
+	}
+
+	public boolean isAdmin(Long clubId) {
+		return clubMemberRepository.findByClubIdAndUserId(clubId, currentUserId())
+			.filter(cm -> cm.getClubMemberStatus() == ClubMemberStatus.ACTIVE)
+			.map(cm -> {
+				ClubMemberRole role = cm.getClubMemberRole();
+				return role == ClubMemberRole.ADMIN || role == ClubMemberRole.OWNER;
+			})
+			.orElse(false);
+	}
+
+	public boolean isOwner(Long clubId) {
+		return clubMemberRepository.findByClubIdAndUserId(clubId, currentUserId())
+			.filter(cm -> cm.getClubMemberStatus() == ClubMemberStatus.ACTIVE)
+			.map(cm -> cm.getClubMemberRole() == ClubMemberRole.OWNER)
+			.orElse(false);
+	}
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,8 @@
+pluginManagement {
+    plugins {
+        id 'org.jetbrains.kotlin.jvm' version '2.1.10'
+    }
+}
 rootProject.name = 'cluvr'
 
 include ':cluvr-api', ':cluvr-batch', ':cluvr-chat', ':cluvr-notifications'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,8 +1,4 @@
-pluginManagement {
-    plugins {
-        id 'org.jetbrains.kotlin.jvm' version '2.1.10'
-    }
-}
+
 rootProject.name = 'cluvr'
 
 include ':cluvr-api', ':cluvr-batch', ':cluvr-chat', ':cluvr-notifications'


### PR DESCRIPTION

## 📌 개요
1. 클럽 멤버용 시큐리티 어노테이션 구성하여 메서드 별로 클럽 내부 권한 설정이 가능하도록 함
2. 어드민 전용 이메일 도메인을 application.yml에 추가하여 해당 이메일로 가입시 자동으로 어드민이 되도록 함
![화면 캡처 2025-06-20 165633](https://github.com/user-attachments/assets/3c34b3be-4174-412e-b41d-fd2c0a104bf0)
4. 기타 인증 인가 파트에 명확하지 않았던 예외나 응답을 더욱 명화하게 리팩토링함
## 🔍 관련 이슈

- Closes #106
---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 클럽 소유자 권한 이전 기능이 추가되었습니다.
    - 클럽 멤버 관련 API에 역할 기반 접근 제어가 적용되었습니다.
    - 이메일 도메인에 따라 회원가입 시 자동으로 관리자/일반 사용자 역할이 부여됩니다.
    - 클럽 소유자, 관리자, 멤버 권한을 확인하는 보안 어노테이션이 도입되었습니다.
    - 클럽 멤버십 상태 및 역할을 검증하는 보안 서비스가 추가되었습니다.
- **개선사항**
    - 클럽 탈퇴, 멤버 강퇴, 회원 탈퇴 시 성공 메시지가 반환됩니다.
    - 클럽 관련 보안 정책이 세분화되어 보다 안전하게 동작합니다.
    - 보안 설정이 클럽 관련 요청과 일반 요청으로 분리되어 관리됩니다.
- **버그 수정**
    - 일부 엔드포인트의 응답 코드 및 메시지 일관성이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->