### PR TITLE
Feat/#111:api url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ out/
 
 # 나머지 yml 파일은 추적
 !*.yml
+/cluvr-api/src/main/resources/application.yml
+/cluvr-api/src/test/resources/application-test.yml

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/analytics/controller/StatTestController.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/analytics/controller/StatTestController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.cluvrapi.domain.board.service.BoardEvent;
@@ -12,6 +13,7 @@ import com.example.cluvrapi.domain.clover.enums.Tier;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api")
 public class StatTestController {
 
 	private final ApplicationEventPublisher publisher; // 이벤트 발행

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/controller/ProblemFormController.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/controller/ProblemFormController.java
@@ -31,7 +31,7 @@ import com.example.cluvrapi.global.response.ResponseCode;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/clubs/{clubId}/problem-forms")
+@RequestMapping("/api/clubs/{clubId}/problem-forms")
 public class ProblemFormController {
 	private final ProblemFormService problemFormService;
 

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/controller/SubmissionFormController.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/applicationForm/controller/SubmissionFormController.java
@@ -29,7 +29,7 @@ import com.example.cluvrapi.global.response.ResponseCode;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/clubs/{clubId}/submission-forms")
+@RequestMapping("/api/clubs/{clubId}/submission-forms")
 public class SubmissionFormController {
 
 	private final SubmissionFormService submissionFormService;

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/auth/controller/AuthController.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/auth/controller/AuthController.java
@@ -1,6 +1,11 @@
 package com.example.cluvrapi.domain.auth.controller;
 
-import static com.example.cluvrapi.global.response.ResponseCode.*;
+import static com.example.cluvrapi.global.response.ResponseCode.CREATED;
+import static com.example.cluvrapi.global.response.ResponseCode.OK;
+
+import jakarta.validation.Valid;
+
+import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,11 +24,8 @@ import com.example.cluvrapi.global.exception.BusinessException;
 import com.example.cluvrapi.global.response.BaseResponse;
 import com.example.cluvrapi.global.response.ResponseCode;
 
-import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
-
 @RestController
-@RequestMapping("/auth")
+@RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class AuthController {
 	private final AuthService authService;

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/board/controller/BoardController.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/board/controller/BoardController.java
@@ -32,7 +32,7 @@ import com.example.cluvrapi.global.response.BaseResponse;
 import com.example.cluvrapi.global.response.ResponseCode;
 
 @RestController
-@RequestMapping("/boards")
+@RequestMapping("/api/boards")
 @RequiredArgsConstructor
 @Validated
 public class BoardController {

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/clover/controller/CloverController.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/clover/controller/CloverController.java
@@ -17,7 +17,7 @@ import com.example.cluvrapi.global.response.ResponseCode;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/clovers")
+@RequestMapping("/api/clovers")
 public class CloverController {
 	private final CloverService cloverService;
 

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/club/controller/ClubController.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/club/controller/ClubController.java
@@ -45,7 +45,7 @@ import com.example.cluvrapi.global.response.ResponseCode;
  */
 
 @RestController
-@RequestMapping("/clubs")
+@RequestMapping("/api/clubs")
 @RequiredArgsConstructor
 public class ClubController {
 

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/clubMember/controller/ClubMemberController.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/clubMember/controller/ClubMemberController.java
@@ -1,5 +1,9 @@
 package com.example.cluvrapi.domain.clubMember.controller;
 
+import jakarta.validation.Valid;
+
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -24,11 +28,8 @@ import com.example.cluvrapi.domain.common.dto.AuthUser;
 import com.example.cluvrapi.global.response.BaseResponse;
 import com.example.cluvrapi.global.response.ResponseCode;
 
-import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
-
 @RestController
-@RequestMapping("/clubs/{clubId}")
+@RequestMapping("/api/clubs/{clubId}")
 @RequiredArgsConstructor
 
 public class ClubMemberController {

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/gem/controller/GemController.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/gem/controller/GemController.java
@@ -23,7 +23,7 @@ import com.example.cluvrapi.global.response.BaseResponse;
 import com.example.cluvrapi.global.response.ResponseCode;
 
 @RestController
-@RequestMapping("/gems")
+@RequestMapping("/api/gems")
 @RequiredArgsConstructor
 public class GemController {
 

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/join/controller/JoinController.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/join/controller/JoinController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.cluvrapi.domain.common.annotation.Auth;
@@ -37,6 +38,7 @@ import com.example.cluvrapi.global.response.ResponseCode;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api")
 public class JoinController {
 
 	private final JoinService joinService;

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/reaction/controller/ReactionController.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/reaction/controller/ReactionController.java
@@ -22,7 +22,7 @@ import com.example.cluvrapi.global.response.ResponseCode;
 @Validated
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/reactions")
+@RequestMapping("/api/reactions")
 public class ReactionController {
 
 	private final ReactionService reactionService;

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/reply/controller/ReplyController.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/reply/controller/ReplyController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -34,6 +35,7 @@ import com.example.cluvrapi.global.response.ResponseCode;
 @RestController
 @RequiredArgsConstructor
 @Validated
+@RequestMapping("/api")
 public class ReplyController {
 	private final ReplyService replyService;
 

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/til/controller/TilController.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/til/controller/TilController.java
@@ -28,7 +28,7 @@ import com.example.cluvrapi.global.response.BaseResponse;
 import com.example.cluvrapi.global.response.ResponseCode;
 
 @RestController
-@RequestMapping("/clubs/{clubId}/til")
+@RequestMapping("/api/clubs/{clubId}/til")
 @RequiredArgsConstructor
 public class TilController {
 

--- a/cluvr-api/src/main/java/com/example/cluvrapi/domain/user/controller/UserController.java
+++ b/cluvr-api/src/main/java/com/example/cluvrapi/domain/user/controller/UserController.java
@@ -1,5 +1,9 @@
 package com.example.cluvrapi.domain.user.controller;
 
+import jakarta.validation.Valid;
+
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -21,11 +25,8 @@ import com.example.cluvrapi.domain.user.service.UserService;
 import com.example.cluvrapi.global.response.BaseResponse;
 import com.example.cluvrapi.global.response.ResponseCode;
 
-import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
-
 @RestController
-@RequestMapping("/users")
+@RequestMapping("/api/users")
 @RequiredArgsConstructor
 public class UserController {
 

--- a/cluvr-api/src/main/resources/docker-compose.yml
+++ b/cluvr-api/src/main/resources/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3"
+services:
+  rabbitmq:
+    image: rabbitmq:3-management
+    container_name: rabbitmq
+    ports:
+      - "5672:5672"     # 내부 AMQP 통신 포트 (코드에서 이 포트로 접속함)
+      - "15672:15672"   # 웹 대시보드 GUI
+    environment:
+      RABBITMQ_DEFAULT_USER: guest
+      RABBITMQ_DEFAULT_PASS: guest

--- a/cluvr-notifications/Dockerfile
+++ b/cluvr-notifications/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:17
+WORKDIR /app
+COPY build/libs/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION


## 📌 개요

라우팅 경로 설정을 위해서 컨트롤러 mapping url 앞에 api를 추가하였습니다.

---

## 🔍 관련 이슈



- Closes #111 

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - RabbitMQ 서비스를 위한 Docker Compose 설정 파일이 추가되었습니다.
  - cluvr-notifications 서비스를 위한 Dockerfile이 추가되었습니다.

- **변경 사항**
  - 모든 API 엔드포인트의 기본 URL 경로에 `/api`가 추가되어, 클라이언트 요청 시 `/api` 접두사를 사용해야 합니다.
  - 특정 YAML 설정 파일의 Git 추적 방식이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->