### PR TITLE
Feat/#128:이메일 인증 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ out/
 
 ### VS Code ###
 .vscode/
+src/main/resources/application-local.yml

--- a/build.gradle
+++ b/build.gradle
@@ -94,6 +94,9 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
     testCompileOnly 'org.projectlombok:lombok'
+
+    // mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/cluvrapi/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/cluvrapi/domain/auth/controller/AuthController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.example.cluvrapi.domain.auth.dto.request.LoginUserRequestDto;
 import com.example.cluvrapi.domain.auth.dto.request.SignUpUserRequestDto;
+import com.example.cluvrapi.domain.auth.dto.request.SignUpVerifyRequestDto;
 import com.example.cluvrapi.domain.auth.dto.response.LoginUserResponseDto;
 import com.example.cluvrapi.domain.auth.dto.response.SignUpUserResponseDto;
 import com.example.cluvrapi.domain.auth.service.AuthService;
@@ -31,12 +32,16 @@ public class AuthController {
 	private final AuthService authService;
 
 	@PostMapping("/signup")
-	public ResponseEntity<BaseResponse<SignUpUserResponseDto>> signUp(
-		@Valid @RequestBody SignUpUserRequestDto signUpUserRequestDto) {
-		SignUpUserResponseDto responseDto = authService.signUp(signUpUserRequestDto);
+	public ResponseEntity<BaseResponse<String>> signUp(
+		@Valid @RequestBody SignUpUserRequestDto dto
+	) {
+		authService.signUp(dto);
 		return ResponseEntity
 			.status(HttpStatus.CREATED)
-			.body(BaseResponse.success(responseDto, CREATED));
+			.body(BaseResponse.success(
+				"회원가입 요청이 성공적으로 전송되었습니다. 이메일 인증을 진행해주세요.",
+				CREATED
+			));
 	}
 
 	@PostMapping("/login")
@@ -60,5 +65,18 @@ public class AuthController {
 			throw new BusinessException(ResponseCode.TOKEN_INVALID);
 		}
 		return authorizationHeader.substring(7);
+	}
+
+	@PostMapping("/verify")
+	public ResponseEntity<BaseResponse<String>> verifyEmail(
+		@Valid @RequestBody SignUpVerifyRequestDto req
+	) {
+		authService.completeSignUp(req);
+		return ResponseEntity
+			.status(HttpStatus.CREATED)
+			.body(BaseResponse.success(
+				"이메일 인증이 완료되었습니다.",
+				CREATED
+			));
 	}
 }

--- a/src/main/java/com/example/cluvrapi/domain/auth/dto/request/SignUpVerifyCacheRequestDto.java
+++ b/src/main/java/com/example/cluvrapi/domain/auth/dto/request/SignUpVerifyCacheRequestDto.java
@@ -1,0 +1,16 @@
+package com.example.cluvrapi.domain.auth.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(force = true)
+public class SignUpVerifyCacheRequestDto {
+	private final SignUpUserRequestDto signUpRequest;
+	private final String verificationCode;
+
+	public SignUpVerifyCacheRequestDto(SignUpUserRequestDto signUpRequest, String verificationCode) {
+		this.signUpRequest = signUpRequest;
+		this.verificationCode = verificationCode;
+	}
+}

--- a/src/main/java/com/example/cluvrapi/domain/auth/dto/request/SignUpVerifyRequestDto.java
+++ b/src/main/java/com/example/cluvrapi/domain/auth/dto/request/SignUpVerifyRequestDto.java
@@ -1,0 +1,13 @@
+package com.example.cluvrapi.domain.auth.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(force = true)
+public class SignUpVerifyRequestDto {
+	/** 가입 시 사용한 이메일 주소 */
+	private String email;
+	/** 이메일로 전송된 6자리 인증번호 */
+	private String code;
+}

--- a/src/main/java/com/example/cluvrapi/domain/auth/dto/request/SignUpVerifyRequestDto.java
+++ b/src/main/java/com/example/cluvrapi/domain/auth/dto/request/SignUpVerifyRequestDto.java
@@ -1,5 +1,8 @@
 package com.example.cluvrapi.domain.auth.dto.request;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -7,7 +10,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(force = true)
 public class SignUpVerifyRequestDto {
 	/** 가입 시 사용한 이메일 주소 */
+	@NotBlank(message = "이메일은 필수입니다.")
+	@Email(message = "올바른 이메일 형식이 아닙니다.")
 	private String email;
 	/** 이메일로 전송된 6자리 인증번호 */
+	@NotBlank(message = "인증 코드는 필수입니다.")
+	@Pattern(regexp = "^[0-9]{6}$", message = "인증 코드는 6자리 숫자여야 합니다.")
 	private String code;
 }

--- a/src/main/java/com/example/cluvrapi/domain/auth/properties/AppProperties.java
+++ b/src/main/java/com/example/cluvrapi/domain/auth/properties/AppProperties.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 @Component
 @ConfigurationProperties(prefix = "app")
 public class AppProperties {
+
 	private List<String> adminDomains = new ArrayList<>();
 	public List<String> getAdminDomains() { return adminDomains; }
 	public void setAdminDomains(List<String> domains) { this.adminDomains = domains; }

--- a/src/main/java/com/example/cluvrapi/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/cluvrapi/domain/auth/service/AuthService.java
@@ -2,6 +2,7 @@ package com.example.cluvrapi.domain.auth.service;
 
 import com.example.cluvrapi.domain.auth.dto.request.LoginUserRequestDto;
 import com.example.cluvrapi.domain.auth.dto.request.SignUpUserRequestDto;
+import com.example.cluvrapi.domain.auth.dto.request.SignUpVerifyRequestDto;
 import com.example.cluvrapi.domain.auth.dto.response.LoginUserResponseDto;
 import com.example.cluvrapi.domain.auth.dto.response.SignUpUserResponseDto;
 
@@ -22,7 +23,7 @@ public interface AuthService {
 	 * @return SignUpUserResponseDto 설명: 저장된 사용자 정보로 구성된 DTO
 	 * @throws BusinessException 설명: 이메일 또는 전화번호 중복, 비밀번호·비밀번호 확인 불일치 등 검증 실패 시 발생
 	 */
-	SignUpUserResponseDto signUp(SignUpUserRequestDto requestDto);
+	void signUp(SignUpUserRequestDto requestDto);
 
 	/**
 	 * 설명: 기존 사용자의 로그인 인증을 수행하고 JWT 토큰을 발급합니다.
@@ -46,5 +47,9 @@ public interface AuthService {
 	 * @throws BusinessException 설명: 토큰 미제공, 토큰 무효, 블랙리스트 등록 실패 등 처리 중 오류 발생 시
 	 */
 	void logout(String accessToken);
+
+
+	/** 2) 토큰 검증 후 실제 회원가입 처리 */
+	SignUpUserResponseDto completeSignUp(SignUpVerifyRequestDto requestDto);
 
 }

--- a/src/main/java/com/example/cluvrapi/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/cluvrapi/domain/auth/service/AuthService.java
@@ -49,7 +49,16 @@ public interface AuthService {
 	void logout(String accessToken);
 
 
-	/** 2) 토큰 검증 후 실제 회원가입 처리 */
+	/**
+	 * 설명: 이메일 인증 코드를 검증하고 회원가입을 완료합니다.
+	 *
+	 * <p>이 메서드는 Redis에 캐시된 회원가입 요청을 조회하여 인증 코드를 검증하고,
+	 * 검증 성공 시 사용자 엔티티와 연관된 카테고리, 클로버 엔티티를 생성하고 저장합니다.
+	 *
+	 * @param requestDto 설명: 이메일과 인증 코드를 포함한 검증 요청 정보
+	 * @return SignUpUserResponseDto 설명: 저장된 사용자 정보로 구성된 DTO
+	 * @throws BusinessException 설명: 인증 요청 없음, 만료, 코드 불일치 등의 경우 발생
+	 */
 	SignUpUserResponseDto completeSignUp(SignUpVerifyRequestDto requestDto);
 
 }

--- a/src/main/java/com/example/cluvrapi/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/cluvrapi/domain/auth/service/AuthServiceImpl.java
@@ -1,7 +1,14 @@
 package com.example.cluvrapi.domain.auth.service;
 
+import java.time.Duration;
+import java.util.Random;
+
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -12,6 +19,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.example.cluvrapi.domain.auth.dto.request.LoginUserRequestDto;
 import com.example.cluvrapi.domain.auth.dto.request.SignUpUserRequestDto;
+import com.example.cluvrapi.domain.auth.dto.request.SignUpVerifyCacheRequestDto;
+import com.example.cluvrapi.domain.auth.dto.request.SignUpVerifyRequestDto;
 import com.example.cluvrapi.domain.auth.dto.response.LoginUserResponseDto;
 import com.example.cluvrapi.domain.auth.dto.response.SignUpUserResponseDto;
 import com.example.cluvrapi.domain.auth.properties.AppProperties;
@@ -41,70 +50,47 @@ public class AuthServiceImpl implements AuthService {
 	private final CategoryRepository categoryRepository;
 	private final CloverService cloverService;
 	private final AppProperties appProperties;
+	private final RedisTemplate<String, Object> redisTemplate;
+	private final Random random = new Random();
+
+	private final JavaMailSender mailSender;
+
+	private static final Duration VERIFY_TTL = Duration.ofMinutes(10);
+
+	@Value("${spring.mail.username}")
+	private String mailFrom;
 
 	@Override
-	@Transactional
-	public SignUpUserResponseDto signUp(SignUpUserRequestDto requestDto) {
-
-
-		if (userRepository.existsByEmail(requestDto.getEmail())) {
-			throw new BusinessException(
-				ResponseCode.INVALID_REQUEST,
-				"이미 사용 중인 이메일입니다."
-			);
+	public void signUp(SignUpUserRequestDto dto) {
+		if (userRepository.existsByEmail(dto.getEmail())) {
+			throw new BusinessException(ResponseCode.INVALID_REQUEST, "이미 사용 중인 이메일입니다.");
 		}
-		if (userRepository.existsByPhoneNumber(requestDto.getPhoneNumber())) {
-			throw new BusinessException(
-				ResponseCode.INVALID_REQUEST,
-				"이미 등록된 전화번호입니다."
-			);
+		if (userRepository.existsByPhoneNumber(dto.getPhoneNumber())) {
+			throw new BusinessException(ResponseCode.INVALID_REQUEST, "이미 등록된 전화번호입니다.");
 		}
-		if (!requestDto.getPassword().equals(requestDto.getConfirmPassword())) {
-			throw new BusinessException(
-				ResponseCode.INVALID_REQUEST,
-				"비밀번호와 비밀번호 확인이 일치하지 않습니다."
-			);
+		if (!dto.getPassword().equals(dto.getConfirmPassword())) {
+			throw new BusinessException(ResponseCode.INVALID_REQUEST, "비밀번호와 확인이 일치하지 않습니다.");
 		}
 
-		String email = requestDto.getEmail().toLowerCase();
-		String domain = email.substring(email.indexOf("@") + 1);
+		String code = String.format("%06d", random.nextInt(900_000) + 100_000);
+		String key = "signup:verify:" + dto.getEmail().toLowerCase();
+		SignUpVerifyCacheRequestDto cacheDto = new SignUpVerifyCacheRequestDto(dto, code);
+		redisTemplate.opsForValue().set(key, cacheDto, VERIFY_TTL);
 
-		UserRole assignedRole = appProperties.getAdminDomains().contains(domain)
-			? UserRole.ADMIN
-			: UserRole.USER;
-
-		String encodedPassword = passwordEncoder.encode(requestDto.getPassword());
-
-		User newUser = new User(
-			null,                                    // id auto-generated
-			requestDto.getName(),                    // name
-			requestDto.getBirthday(),                // birthday
-			email,                                   // email (소문자)
-			requestDto.getPhoneNumber(),             // phoneNumber
-			assignedRole,                            // UserRole: USER or ADMIN
-			requestDto.getGender(),                  // gender
-			requestDto.getCategoryType(),            // categoryDetail
-			encodedPassword,                         // encrypted password
-			0,                                       // gem 기본값
-			requestDto.getImageUrl(),                // imageUrl
-			false                                    // isDeleted
+		SimpleMailMessage msg = new SimpleMailMessage();
+		msg.setFrom(mailFrom);
+		msg.setTo(dto.getEmail());
+		msg.setSubject("【Cluvr】 회원가입 인증번호 안내");
+		msg.setText(
+			"안녕하세요, Cluvr입니다.\n\n" +
+				"회원가입을 위해 아래 인증번호를 입력해 주세요:\n\n" +
+				code + "\n\n" +
+				"※ 유효시간: 10분\n" +
+				"감사합니다."
 		);
-
-		User savedUser = userRepository.save(newUser);
-
-		// 6) Category, Clover 등 기존 로직 유지
-		Category newCategory = new Category(
-			savedUser.getId(),
-			requestDto.getCategoryType(),
-			CategoryTargetType.USER
-		);
-		categoryRepository.save(newCategory);
-		cloverService.createClover(
-			CreateCloverRequestDto.from(0, Tier.SPROUT, savedUser.getId())
-		);
-
-		return SignUpUserResponseDto.from(savedUser);
+		mailSender.send(msg);
 	}
+
 
 	@Override
 	@Transactional(readOnly = true)
@@ -165,5 +151,56 @@ public class AuthServiceImpl implements AuthService {
 		}
 
 	}
-}
+	@Override
+	@Transactional
+	public SignUpUserResponseDto completeSignUp(SignUpVerifyRequestDto req) {
+		String email = req.getEmail().toLowerCase();
+		String key = "signup:verify:" + email;
+
+		SignUpVerifyCacheRequestDto cache =
+			(SignUpVerifyCacheRequestDto) redisTemplate.opsForValue().get(key);
+		if (cache == null) {
+			throw new BusinessException(ResponseCode.INVALID_REQUEST, "인증 요청이 없거나 만료되었습니다.");
+		}
+		if (!cache.getVerificationCode().equals(req.getCode())) {
+			throw new BusinessException(ResponseCode.INVALID_REQUEST, "인증번호가 일치하지 않습니다.");
+		}
+
+		redisTemplate.delete(key);
+
+		SignUpUserRequestDto dto = cache.getSignUpRequest();
+		String emailLower = dto.getEmail().toLowerCase();
+		String domain = emailLower.substring(emailLower.indexOf('@') + 1);
+		UserRole role = appProperties.getAdminDomains().contains(domain)
+			? UserRole.ADMIN : UserRole.USER;
+
+		User user = new User(
+			null,
+			dto.getName(),
+			dto.getBirthday(),
+			emailLower,
+			dto.getPhoneNumber(),
+			role,
+			dto.getGender(),
+			dto.getCategoryType(),
+			passwordEncoder.encode(dto.getPassword()),
+			0,
+			dto.getImageUrl(),
+			false
+		);
+		User saved = userRepository.save(user);
+
+		categoryRepository.save(new Category(
+			saved.getId(),
+			dto.getCategoryType(),
+			CategoryTargetType.USER
+		));
+		cloverService.createClover(
+			CreateCloverRequestDto.from(0, Tier.SPROUT, saved.getId())
+		);
+
+		return SignUpUserResponseDto.from(saved);
+	}
+	}
+
 

--- a/src/main/java/com/example/cluvrapi/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/cluvrapi/domain/auth/service/AuthServiceImpl.java
@@ -1,7 +1,7 @@
 package com.example.cluvrapi.domain.auth.service;
 
 import java.time.Duration;
-import java.util.Random;
+import java.security.SecureRandom;
 
 import lombok.RequiredArgsConstructor;
 
@@ -51,7 +51,7 @@ public class AuthServiceImpl implements AuthService {
 	private final CloverService cloverService;
 	private final AppProperties appProperties;
 	private final RedisTemplate<String, Object> redisTemplate;
-	private final Random random = new Random();
+	private final SecureRandom random = new SecureRandom();
 
 	private final JavaMailSender mailSender;
 
@@ -73,13 +73,13 @@ public class AuthServiceImpl implements AuthService {
 		}
 
 		String code = String.format("%06d", random.nextInt(900_000) + 100_000);
-		String key = "signup:verify:" + dto.getEmail().toLowerCase();
+		String emailLower = dto.getEmail().toLowerCase();
+		String key = "signup:verify:" + emailLower;
 		SignUpVerifyCacheRequestDto cacheDto = new SignUpVerifyCacheRequestDto(dto, code);
-		redisTemplate.opsForValue().set(key, cacheDto, VERIFY_TTL);
 
+		redisTemplate.opsForValue().set(key, cacheDto, VERIFY_TTL);
 		SimpleMailMessage msg = new SimpleMailMessage();
-		msg.setFrom(mailFrom);
-		msg.setTo(dto.getEmail());
+		msg.setTo(emailLower);
 		msg.setSubject("【Cluvr】 회원가입 인증번호 안내");
 		msg.setText(
 			"안녕하세요, Cluvr입니다.\n\n" +
@@ -88,7 +88,13 @@ public class AuthServiceImpl implements AuthService {
 				"※ 유효시간: 10분\n" +
 				"감사합니다."
 		);
-		mailSender.send(msg);
+		try {
+			mailSender.send(msg);
+		} catch (Exception e) {
+			// 캐시 삭제
+			redisTemplate.delete(key);
+			throw new BusinessException(ResponseCode.DB_FAIL, "이메일 발송에 실패했습니다. 잠시 후 다시 시도해주세요.");
+		}
 	}
 
 
@@ -157,8 +163,14 @@ public class AuthServiceImpl implements AuthService {
 		String email = req.getEmail().toLowerCase();
 		String key = "signup:verify:" + email;
 
-		SignUpVerifyCacheRequestDto cache =
-			(SignUpVerifyCacheRequestDto) redisTemplate.opsForValue().get(key);
+		Object cachedObject = redisTemplate.opsForValue().get(key);
+		if (cachedObject == null) {
+			throw new BusinessException(ResponseCode.INVALID_REQUEST, "인증 요청이 없거나 만료되었습니다.");
+		}
+		if (!(cachedObject instanceof SignUpVerifyCacheRequestDto)) {
+			throw new BusinessException(ResponseCode.DB_FAIL, "잘못된 캐시 데이터입니다.");
+		}
+		SignUpVerifyCacheRequestDto cache = (SignUpVerifyCacheRequestDto) cachedObject;
 		if (cache == null) {
 			throw new BusinessException(ResponseCode.INVALID_REQUEST, "인증 요청이 없거나 만료되었습니다.");
 		}

--- a/src/main/java/com/example/cluvrapi/domain/clubMember/service/ClubMemberServiceImpl.java
+++ b/src/main/java/com/example/cluvrapi/domain/clubMember/service/ClubMemberServiceImpl.java
@@ -2,8 +2,6 @@ package com.example.cluvrapi.domain.clubMember.service;
 
 import java.util.Optional;
 
-import lombok.RequiredArgsConstructor;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -21,11 +19,10 @@ import com.example.cluvrapi.domain.common.dto.AuthUser;
 import com.example.cluvrapi.domain.join.entity.JoinRequest;
 import com.example.cluvrapi.domain.join.enums.JoinStatus;
 import com.example.cluvrapi.domain.join.repository.JoinRequestRepository;
-import com.example.cluvrapi.global.annotation.IsClubAdmin;
-import com.example.cluvrapi.global.annotation.IsClubMember;
-import com.example.cluvrapi.global.annotation.IsClubOwner;
 import com.example.cluvrapi.global.exception.BusinessException;
 import com.example.cluvrapi.global.response.ResponseCode;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/example/cluvrapi/global/config/MailConfig.java
+++ b/src/main/java/com/example/cluvrapi/global/config/MailConfig.java
@@ -1,0 +1,41 @@
+package com.example.cluvrapi.global.config;
+
+import java.util.Properties;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+@Configuration
+public class MailConfig {
+
+	@Value("${spring.mail.host}")
+	private String host;
+
+	@Value("${spring.mail.port}")
+	private int port;
+
+	@Value("${spring.mail.username}")
+	private String username;
+
+	@Value("${spring.mail.password}")
+	private String password;
+
+	@Bean
+	public JavaMailSender javaMailSender() {
+		JavaMailSenderImpl sender = new JavaMailSenderImpl();
+		sender.setHost(host);
+		sender.setPort(port);
+		sender.setUsername(username);
+		sender.setPassword(password);
+
+		Properties props = sender.getJavaMailProperties();
+		props.put("mail.transport.protocol", "smtp");
+		props.put("mail.smtp.auth", true);
+		props.put("mail.smtp.starttls.enable", true);
+
+		return sender;
+	}
+}

--- a/src/main/java/com/example/cluvrapi/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/cluvrapi/global/config/SecurityConfig.java
@@ -85,7 +85,7 @@ public class SecurityConfig {
 			.userDetailsService(userDetailsService)
 			.authorizeHttpRequests(auth -> auth
 				// 회원가입·로그인만 공개
-				.requestMatchers("/auth/signup", "/auth/login", "/my-monitor/**", "/**").permitAll()
+				.requestMatchers("/api/auth/signup", "/api/auth/login", "/api/auth/verify", "/my-monitor/**", "/**").permitAll()
 				// /admin/** 은 ADMIN 권한 필요
 				.requestMatchers("/admin/**").hasRole("ADMIN")
 				// 그 외 모든 요청은 인증된 사용자여야 함

--- a/src/main/java/com/example/cluvrapi/global/response/ResponseCode.java
+++ b/src/main/java/com/example/cluvrapi/global/response/ResponseCode.java
@@ -20,6 +20,7 @@ public enum ResponseCode {
 	VALID_FAIL(HttpStatus.BAD_REQUEST, "유효성 검증에 실패하였습니다."),
 	NOT_FOUND(HttpStatus.NOT_FOUND, "NOT FOUND"),
 
+
 	/* 인증, 인가 */
 	LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "아이디(로그인 이메일) 또는 비밀번호가 잘못 되었습니다. 아이디와 비밀번호를 정확히 입력해 주세요."),
 	AUTH_ANNOTATION_USER_MISMATCH(HttpStatus.UNAUTHORIZED, "@Auth와 AuthUser 타입은 함께 사용되어야 합니다."),


### PR DESCRIPTION


## 📌 개요

이메일 인증을 구현했습니다!
---

## 🔍 관련 이슈

- Closes #128 

---

## 참고 5분 기록 보드
https://www.notion.so/teamsparta/10-5-1fc2dc3ef5148166ba9ec8e4b09d0b64?p=21c2dc3ef51480fa8a15f41bd8a48a8a&pm=s



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 회원가입 시 이메일 인증 절차가 추가되었습니다. 회원가입 요청 후 이메일로 전송된 6자리 인증코드를 입력하여 인증을 완료할 수 있습니다.
    - 이메일 인증을 위한 API 엔드포인트가 추가되었습니다.
    - 메일 발송 기능이 도입되어 회원가입 시 인증 메일이 자동으로 발송됩니다.

- **버그 수정**
    - 인증 관련 엔드포인트 접근 경로가 "/api/auth"로 통일되고, 이메일 인증 엔드포인트가 허용 목록에 추가되었습니다.

- **기타**
    - 불필요한 파일이 버전 관리에서 제외되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->