### PR TITLE
Refactor/#168:가입 요청과 클럽멤버 리팩토링

### DIFF
--- a/src/main/java/com/example/cluvrapi/domain/clubMember/controller/ClubMemberController.java
+++ b/src/main/java/com/example/cluvrapi/domain/clubMember/controller/ClubMemberController.java
@@ -55,7 +55,7 @@ public class ClubMemberController {
 		@RequestBody HandleJoinStatusRequestDto dto,
 		@Auth AuthUser authUser
 	) {
-		clubMemberService.handleJoinRequest(clubId, joinRequestId, dto.getStatus(), authUser);
+		clubMemberService.handleJoinRequest(clubId, joinRequestId, dto, authUser);
 		return ResponseEntity
 			.ok(BaseResponse.success(ResponseCode.OK));
 	}

--- a/src/main/java/com/example/cluvrapi/domain/clubMember/controller/ClubMemberController.java
+++ b/src/main/java/com/example/cluvrapi/domain/clubMember/controller/ClubMemberController.java
@@ -27,13 +27,26 @@ import com.example.cluvrapi.domain.common.dto.AuthUser;
 import com.example.cluvrapi.global.response.BaseResponse;
 import com.example.cluvrapi.global.response.ResponseCode;
 
+/**
+ * 클럽 멤버 관련 요청을 처리하는 컨트롤러입니다.
+ */
+
 @RestController
 @RequestMapping("/api/clubs/{clubId}")
 @RequiredArgsConstructor
-
 public class ClubMemberController {
 
 	private final ClubMemberService clubMemberService;
+
+	/**
+	 * 가입 요청 승인 또는 거절 처리
+	 *
+	 * @param clubId 클럽 ID
+	 * @param joinRequestId 가입 요청 ID
+	 * @param dto 요청 상태 정보 (ACCEPTED / REJECTED 등)
+	 * @param authUser 인증된 사용자 정보
+	 * @author alpomjeong
+	 */
 
 	@PostMapping("/join-requests/{joinRequestId}/status")
 	public ResponseEntity<BaseResponse<Void>> handleJoinStatus(
@@ -47,6 +60,16 @@ public class ClubMemberController {
 			.ok(BaseResponse.success(ResponseCode.OK));
 	}
 
+	/**
+	 * 특정 멤버의 클럽 내 역할(Role) 변경
+	 *
+	 * @param clubId 클럽 ID
+	 * @param targetMemberId 역할을 변경할 대상 멤버 ID
+	 * @param dto 새로운 역할 정보
+	 * @param authUser 인증된 사용자 정보
+	 * @author alpomjeong
+	 */
+
 	@PatchMapping("/members/{memberId}/role")
 	public ResponseEntity<BaseResponse<Void>> changeRole(
 		@PathVariable Long clubId,
@@ -58,6 +81,14 @@ public class ClubMemberController {
 		return ResponseEntity
 			.ok(BaseResponse.success(ResponseCode.OK));
 	}
+
+	/**
+	 * 현재 로그인한 사용자의 클럽 탈퇴 처리
+	 *
+	 * @param clubId 클럽 ID
+	 * @param authUser 인증된 사용자 정보
+	 * @author alpomjeong
+	 */
 
 	@DeleteMapping("/members/me")
 	public ResponseEntity<BaseResponse<String>> withdrawFromClub(
@@ -73,6 +104,15 @@ public class ClubMemberController {
 				)
 			);
 	}
+
+	/**
+	 * 특정 멤버를 클럽에서 강퇴
+	 *
+	 * @param clubId 클럽 ID
+	 * @param memberId 강퇴 대상 멤버 ID
+	 * @param authUser 인증된 사용자 정보
+	 * @author alpomjeong
+	 */
 
 	@DeleteMapping("/members/{memberId}")
 	public ResponseEntity<BaseResponse<String>> kickMember(
@@ -90,6 +130,15 @@ public class ClubMemberController {
 			);
 	}
 
+	/**
+	 * 클럽 멤버 목록 조회 (페이징 처리)
+	 *
+	 * @param clubId 클럽 ID
+	 * @param authUser 인증된 사용자 정보
+	 * @param pageable 페이징 정보
+	 * @author alpomjeong
+	 */
+
 	@GetMapping("/members")
 	public ResponseEntity<BaseResponse<Page<ClubMemberInfoResponseDto>>> listMembers(
 		@PathVariable Long clubId,
@@ -100,6 +149,15 @@ public class ClubMemberController {
 		return ResponseEntity
 			.ok(BaseResponse.success(page, ResponseCode.OK));
 	}
+
+	/**
+	 * 특정 유저의 클럽 내 역할(Role) 조회
+	 *
+	 * @param clubId 클럽 ID
+	 * @param targetUserId 조회 대상 유저 ID
+	 * @param authUser 인증된 사용자 정보
+	 * @author alpomjeong
+	 */
 
 	@GetMapping("/members/{userId}/role")
 	public ResponseEntity<BaseResponse<GetMemberRoleResponseDto>> getMemberRole(
@@ -112,8 +170,16 @@ public class ClubMemberController {
 			.ok(BaseResponse.success(dto, ResponseCode.OK));
 	}
 
-	@PostMapping("/{targetMemberId}/transfer-owner")
+	/**
+	 * 클럽장 권한을 다른 멤버에게 이양
+	 *
+	 * @param clubId 클럽 ID
+	 * @param targetMemberId 새로운 클럽장으로 지정할 멤버 ID
+	 * @param authUser 인증된 사용자 정보
+	 * @author alpomjeong
+	 */
 
+	@PostMapping("/{targetMemberId}/transfer-owner")
 	public ResponseEntity<BaseResponse<Void>> transferOwner(
 		@PathVariable Long clubId,
 		@PathVariable Long targetMemberId,

--- a/src/main/java/com/example/cluvrapi/domain/clubMember/entity/enums/ClubMemberStatus.java
+++ b/src/main/java/com/example/cluvrapi/domain/clubMember/entity/enums/ClubMemberStatus.java
@@ -1,5 +1,22 @@
 package com.example.cluvrapi.domain.clubMember.entity.enums;
 
+/**
+ * 클럽 멤버의 현재 소속 상태를 나타내는 열거형(enum)입니다.
+ */
 public enum ClubMemberStatus {
-	ACTIVE, KICKED, WITHDRAWN
+
+	/**
+	 * 클럽에 정상적으로 소속된 상태
+	 */
+	ACTIVE,
+
+	/**
+	 * 운영자에 의해 클럽에서 강제 탈퇴(강퇴)된 상태
+	 */
+	KICKED,
+
+	/**
+	 * 사용자가 자발적으로 클럽을 탈퇴한 상태
+	 */
+	WITHDRAWN
 }

--- a/src/main/java/com/example/cluvrapi/domain/clubMember/service/ClubMemberService.java
+++ b/src/main/java/com/example/cluvrapi/domain/clubMember/service/ClubMemberService.java
@@ -2,22 +2,21 @@ package com.example.cluvrapi.domain.clubMember.service;
 
 import java.util.List;
 
+import jakarta.validation.constraints.NotNull;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import com.example.cluvrapi.domain.club.entity.Club;
+import com.example.cluvrapi.domain.club.dto.response.MyClubResponseDto;
+import com.example.cluvrapi.domain.clubMember.dto.request.HandleJoinStatusRequestDto;
 import com.example.cluvrapi.domain.clubMember.dto.response.ClubMemberInfoResponseDto;
 import com.example.cluvrapi.domain.clubMember.dto.response.GetMemberRoleResponseDto;
 import com.example.cluvrapi.domain.clubMember.entity.enums.ClubMemberRole;
 import com.example.cluvrapi.domain.common.dto.AuthUser;
-import com.example.cluvrapi.domain.join.enums.JoinStatus;
 import com.example.cluvrapi.global.annotation.IsClubAdmin;
 import com.example.cluvrapi.global.annotation.IsClubMember;
 import com.example.cluvrapi.global.annotation.IsClubOwner;
 import com.example.cluvrapi.global.exception.BusinessException;
-import com.example.cluvrapi.domain.club.dto.response.MyClubResponseDto;
-
-import jakarta.validation.constraints.NotNull;
 
 /**
  * 설명: 클럽 멤버 관련 핵심 비즈니스 로직을 제공하는 서비스 인터페이스입니다.
@@ -40,7 +39,7 @@ public interface ClubMemberService {
 	 * @throws BusinessException 설명: 요청이 존재하지 않거나 권한이 없을 경우 발생
 	 */
 	@IsClubAdmin
-	void handleJoinRequest(Long clubId, Long joinRequestId, JoinStatus status, AuthUser approver);
+	void handleJoinRequest(Long clubId, Long joinRequestId, HandleJoinStatusRequestDto dto, AuthUser approver);
 
 	/**
 	 * 설명: 클럽 내 특정 멤버의 역할을 변경합니다.

--- a/src/main/java/com/example/cluvrapi/domain/clubMember/service/ClubMemberService.java
+++ b/src/main/java/com/example/cluvrapi/domain/clubMember/service/ClubMemberService.java
@@ -35,7 +35,7 @@ public interface ClubMemberService {
 	 *
 	 * @param clubId        설명: 처리할 클럽의 식별자
 	 * @param joinRequestId 설명: 승인/거절할 가입 요청의 식별자
-	 * @param status        설명: 처리할 상태(승인 또는 거절)
+	 * @param dto        설명: 처리할 상태(승인 또는 거절)를 담은 DTO
 	 * @param approver      설명: 요청을 승인/거절하는 운영자 정보
 	 * @throws BusinessException 설명: 요청이 존재하지 않거나 권한이 없을 경우 발생
 	 */

--- a/src/main/java/com/example/cluvrapi/domain/clubMember/service/ClubMemberServiceImpl.java
+++ b/src/main/java/com/example/cluvrapi/domain/clubMember/service/ClubMemberServiceImpl.java
@@ -46,42 +46,27 @@ public class ClubMemberServiceImpl implements ClubMemberService {
 		JoinRequest joinRequest = joinRequestRepository.joinRequestByIdAndClubId(clubId, joinRequestId)
 			.orElseThrow(() -> new BusinessException(ResponseCode.NOT_FOUND, "가입 요청을 찾을 수 없습니다."));
 
-		if (jr.getJoinStatus() != JoinStatus.PENDING) {
+		// 2. 가입 요청 상태 검증
+		if (joinRequest.getJoinStatus() != JoinStatus.PENDING) {
 			throw new BusinessException(ResponseCode.INVALID_REQUEST, "이미 처리된 요청입니다.");
 		}
 
-		Club club = jr.getClub();
-		long activeCount = clubMemberRepository.countByClubIdAndStatus(clubId, ClubMemberStatus.ACTIVE);
-		if (activeCount >= club.getMaxMemberCount()) {
-			throw new BusinessException(ResponseCode.INVALID_REQUEST, "클럽 최대 인원을 초과했습니다.");
-		}
-		var user = jr.getUser();
+		// 3. 클럽, 유저, DTO 정보 추출
+		Club club = joinRequest.getClub();
+		User user = joinRequest.getUser();
+		JoinStatus status = dto.getStatus();
 
-		if (status == JoinStatus.APPROVED) {
-			Optional<ClubMember> existing = clubMemberRepository.findByClubAndUserWithAnyStatus(club, user);
-
-			if (existing.isPresent()) {
-				ClubMember cm = existing.get();
-				switch (cm.getClubMemberStatus()) {
-					case ACTIVE:
-						throw new BusinessException(ResponseCode.INVALID_REQUEST, "이미 가입된 유저입니다.");
-					case KICKED:
-						throw new BusinessException(ResponseCode.INVALID_REQUEST, "강퇴된 유저는 재가입할 수 없습니다.");
-					case WITHDRAWN:
-						cm.rejoin();
-						break;
+		// 4. 승인 또는 거절 처리
+		switch (status) {
+			case APPROVED -> {
+				Long activeCount = clubMemberRepository.countByClubIdAndStatus(clubId, ClubMemberStatus.ACTIVE);
+				if (activeCount >= club.getMaxMemberCount()) {
+					throw new BusinessException(ResponseCode.INVALID_REQUEST, "클럽 최대 인원을 초과했습니다.");
 				}
-			} else {
-				ClubMember nm = new ClubMember(club, user, ClubMemberRole.MEMBER, ClubMemberStatus.ACTIVE);
-				clubMemberRepository.save(nm);
+				handleApproval(club, user, joinRequest);
 			}
-
-			jr.approve();
-
-		} else if (status == JoinStatus.REJECTED) {
-			jr.reject();
-		} else {
-			throw new BusinessException(ResponseCode.INVALID_REQUEST, "승인 또는 거절만 가능합니다.");
+			case REJECTED -> joinRequest.reject();
+			default -> throw new BusinessException(ResponseCode.INVALID_REQUEST, "승인 또는 거절만 가능합니다.");
 		}
 	}
 
@@ -222,5 +207,27 @@ public class ClubMemberServiceImpl implements ClubMemberService {
 			.collect(Collectors.toList());
 	}
 
+	/**
+	 * 가입 요청 승인 처리 메서드.
+	 * 기존 ClubMember 상태를 확인하여 예외 처리 또는 복귀/신규 생성 후, 가입 요청 상태를 APPROVED 로 변경한다.
+	 */
+
+	private void handleApproval(Club club, User user, JoinRequest joinRequest) {
+		Optional<ClubMember> clubMemberOpt = clubMemberRepository.findByClubAndUserWithAnyStatus(club, user);
+
+		if (clubMemberOpt.isPresent()) {
+			ClubMember cm = clubMemberOpt.get();
+			switch (cm.getClubMemberStatus()) {
+				case ACTIVE -> throw new BusinessException(ResponseCode.INVALID_REQUEST, "이미 가입된 유저입니다.");
+				case KICKED -> throw new BusinessException(ResponseCode.INVALID_REQUEST, "강퇴된 유저는 재가입할 수 없습니다.");
+				case WITHDRAWN -> cm.rejoin();
+			}
+		} else {
+			ClubMember nm = new ClubMember(club, user, ClubMemberRole.MEMBER, ClubMemberStatus.ACTIVE);
+			clubMemberRepository.save(nm);
+		}
+
+		joinRequest.approve();
+	}
 }
 

--- a/src/main/java/com/example/cluvrapi/domain/clubMember/service/ClubMemberServiceImpl.java
+++ b/src/main/java/com/example/cluvrapi/domain/clubMember/service/ClubMemberServiceImpl.java
@@ -145,7 +145,7 @@ public class ClubMemberServiceImpl implements ClubMemberService {
 		target.kick();
 
 		// JoinRequest SoftDeleted 적용
-		JoinRequest joinRequest = joinRequestRepository.findJoinByClubIdAndUserId(clubId, operator.id()).orElseThrow(
+		JoinRequest joinRequest = joinRequestRepository.findJoinByClubIdAndUserId(clubId, target.getUser().getId()).orElseThrow(
 			() -> new BusinessException(ResponseCode.INVALID_REQUEST, "가입된 요청이 없습니다.")
 		);
 

--- a/src/main/java/com/example/cluvrapi/domain/clubMember/service/ClubMemberServiceImpl.java
+++ b/src/main/java/com/example/cluvrapi/domain/clubMember/service/ClubMemberServiceImpl.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.example.cluvrapi.domain.club.entity.Club;
 import com.example.cluvrapi.domain.club.repository.ClubRepository;
+import com.example.cluvrapi.domain.clubMember.dto.request.HandleJoinStatusRequestDto;
 import com.example.cluvrapi.domain.clubMember.dto.response.ClubMemberInfoResponseDto;
 import com.example.cluvrapi.domain.clubMember.dto.response.GetMemberRoleResponseDto;
 import com.example.cluvrapi.domain.clubMember.entity.ClubMember;
@@ -40,8 +41,9 @@ public class ClubMemberServiceImpl implements ClubMemberService {
 
 	@Transactional
 	@Override
-	public void handleJoinRequest(Long clubId, Long joinRequestId, JoinStatus status, AuthUser approver) {
-		JoinRequest jr = joinRequestRepository.joinRequestByIdAndClubId(clubId, joinRequestId)
+	public void handleJoinRequest(Long clubId, Long joinRequestId, HandleJoinStatusRequestDto dto, AuthUser approver) {
+		// 1. 요청 정보 조회
+		JoinRequest joinRequest = joinRequestRepository.joinRequestByIdAndClubId(clubId, joinRequestId)
 			.orElseThrow(() -> new BusinessException(ResponseCode.NOT_FOUND, "가입 요청을 찾을 수 없습니다."));
 
 		if (jr.getJoinStatus() != JoinStatus.PENDING) {

--- a/src/main/java/com/example/cluvrapi/domain/clubMember/service/ClubMemberServiceImpl.java
+++ b/src/main/java/com/example/cluvrapi/domain/clubMember/service/ClubMemberServiceImpl.java
@@ -121,6 +121,13 @@ public class ClubMemberServiceImpl implements ClubMemberService {
 			throw new BusinessException(ResponseCode.INVALID_REQUEST, "이미 탈퇴 또는 강퇴된 멤버입니다.");
 		}
 		me.withdraw();
+
+		// JoinRequest SoftDeleted 적용
+		JoinRequest joinRequest = joinRequestRepository.findJoinByClubIdAndUserId(clubId, user.id()).orElseThrow(
+			() -> new BusinessException(ResponseCode.INVALID_REQUEST, "가입된 요청이 없습니다.")
+		);
+
+		joinRequest.delete();
 	}
 
 	@Override
@@ -134,7 +141,15 @@ public class ClubMemberServiceImpl implements ClubMemberService {
 		if (target.getClubMemberStatus() != ClubMemberStatus.ACTIVE) {
 			throw new BusinessException(ResponseCode.INVALID_REQUEST, "이미 탈퇴 또는 강퇴된 멤버입니다.");
 		}
+
 		target.kick();
+
+		// JoinRequest SoftDeleted 적용
+		JoinRequest joinRequest = joinRequestRepository.findJoinByClubIdAndUserId(clubId, operator.id()).orElseThrow(
+			() -> new BusinessException(ResponseCode.INVALID_REQUEST, "가입된 요청이 없습니다.")
+		);
+
+		joinRequest.delete();
 	}
 
 	@Override

--- a/src/main/java/com/example/cluvrapi/domain/join/entity/JoinRequest.java
+++ b/src/main/java/com/example/cluvrapi/domain/join/entity/JoinRequest.java
@@ -103,11 +103,13 @@ public class JoinRequest {
 	}
 
 	/**
-	 * 설명: 가입 상태를 취소로 바꾸어주는 메서드
 	 * 설명: 가입 요청을 Soft Deleted 해주는 메서드
 	 *
 	 * @author sinyoung0403
 	 */
+	public void delete() {
+		this.isDeleted = true;
+	}
 
 	/**
 	 * 설명: 가입 요청을 approve 해주는 메서드

--- a/src/main/java/com/example/cluvrapi/domain/join/entity/JoinRequest.java
+++ b/src/main/java/com/example/cluvrapi/domain/join/entity/JoinRequest.java
@@ -104,16 +104,26 @@ public class JoinRequest {
 
 	/**
 	 * 설명: 가입 상태를 취소로 바꾸어주는 메서드
+	 * 설명: 가입 요청을 Soft Deleted 해주는 메서드
 	 *
 	 * @author sinyoung0403
 	 */
-	public void updateJoinStatus() {
-		this.joinStatus = JoinStatus.CANCELED;
-	}
+
+	/**
+	 * 설명: 가입 요청을 approve 해주는 메서드
+	 *
+	 * @author sinyoung0403
+	 */
 
 	public void approve() {
 		this.joinStatus = JoinStatus.APPROVED;
 	}
+
+	/**
+	 * 설명: 가입 요청을 reject 해주는 메서드
+	 *
+	 * @author sinyoung0403
+	 */
 
 	public void reject() {
 		this.joinStatus = JoinStatus.REJECTED;

--- a/src/main/java/com/example/cluvrapi/domain/join/enums/JoinStatus.java
+++ b/src/main/java/com/example/cluvrapi/domain/join/enums/JoinStatus.java
@@ -7,6 +7,5 @@ package com.example.cluvrapi.domain.join.enums;
 public enum JoinStatus {
 	PENDING,    // 요청됨 (아직 승인되지 않음)
 	APPROVED,   // 승인됨
-	REJECTED,   // 거절됨
-	CANCELED    // 신청자가 요청 취소함
+	REJECTED   // 거절됨
 }

--- a/src/main/java/com/example/cluvrapi/domain/join/repository/JoinRequestRepositoryQuery.java
+++ b/src/main/java/com/example/cluvrapi/domain/join/repository/JoinRequestRepositoryQuery.java
@@ -22,7 +22,7 @@ public interface JoinRequestRepositoryQuery {
 	 *
 	 * @param clubId 클럽 고유 식별자
 	 * @param userId 유저 고유 식별자
-	 * @return 가입 요청이 존재하면 true, 그렇지 않으면 false
+	 * @return Optional<JoinRequest> 가입 요청
 	 * @author sinyoung0403
 	 */
 

--- a/src/main/java/com/example/cluvrapi/domain/join/repository/JoinRequestRepositoryQuery.java
+++ b/src/main/java/com/example/cluvrapi/domain/join/repository/JoinRequestRepositoryQuery.java
@@ -26,7 +26,7 @@ public interface JoinRequestRepositoryQuery {
 	 * @author sinyoung0403
 	 */
 
-	boolean existsJoinByClubIdAndUserId(Long clubId, Long userId);
+	Optional<JoinRequest> findJoinByClubIdAndUserId(Long clubId, Long userId);
 
 	/**
 	 * 설명: 특정 클럽에 대한 모든 가입 요청 목록을 페이징하여 조회하는 쿼리문

--- a/src/main/java/com/example/cluvrapi/domain/join/repository/JoinRequestRepositoryQueryImpl.java
+++ b/src/main/java/com/example/cluvrapi/domain/join/repository/JoinRequestRepositoryQueryImpl.java
@@ -34,14 +34,15 @@ public class JoinRequestRepositoryQueryImpl implements JoinRequestRepositoryQuer
 	private final JPAQueryFactory jpaQueryFactory;
 
 	@Override
-	public boolean existsJoinByClubIdAndUserId(Long clubId, Long userId) {
-		return jpaQueryFactory
-			.selectOne()
-			.from(joinRequest)
-			.where(joinRequest.club.id.eq(clubId)
-				.and(joinRequest.user.id.eq(userId))
-				.and(joinRequest.isDeleted.isFalse()))
-			.fetchFirst() != null;
+	public Optional<JoinRequest> findJoinByClubIdAndUserId(Long clubId, Long userId) {
+		return Optional.ofNullable(
+			jpaQueryFactory
+				.selectFrom(joinRequest)
+				.where(joinRequest.club.id.eq(clubId)
+					.and(joinRequest.user.id.eq(userId))
+					.and(joinRequest.isDeleted.isFalse()))
+				.fetchOne()
+		);
 	}
 
 	@Override

--- a/src/main/java/com/example/cluvrapi/domain/join/service/JoinServiceImpl.java
+++ b/src/main/java/com/example/cluvrapi/domain/join/service/JoinServiceImpl.java
@@ -1,6 +1,7 @@
 package com.example.cluvrapi.domain.join.service;
 
 import java.util.Map;
+import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
 
@@ -229,6 +230,8 @@ public class JoinServiceImpl implements JoinService {
 		if (alreadyRequested) {
 			throw new BusinessException(ResponseCode.INVALID_REQUEST, "이미 가입 신청한 클럽입니다.");
 		}
+		Optional<JoinRequest> alreadyRequested = joinRequestRepository.findJoinByClubIdAndUserId(club.getId(),
+			user.getId());
 
 		// 2. 이미 가입된 유저인지 조회
 		if (clubMemberRepository.findByClubIdAndUserId(club.getId(), user.getId()).isPresent()) {

--- a/src/main/java/com/example/cluvrapi/domain/join/service/JoinServiceImpl.java
+++ b/src/main/java/com/example/cluvrapi/domain/join/service/JoinServiceImpl.java
@@ -62,7 +62,6 @@ public class JoinServiceImpl implements JoinService {
 	private final NotificationProducer notificationProducer;
 	private final JoinRedisService joinRedisService;
 	private final ClubMemberRepository clubMemberRepository;
-	private final ClubValidator clubValidator;
 
 	/**
 	 * 상수 선언
@@ -119,11 +118,6 @@ public class JoinServiceImpl implements JoinService {
 	@Override
 	@Transactional(readOnly = true)
 	public PageResponseDto<MyClubJoinResponseDto> findJoinRequestByClubId(Long userId, Long clubId, Pageable pageable) {
-		ClubMember findClubMember = clubMemberRepository.findByClubIdAndUserId(clubId, userId)
-			.orElseThrow(() -> new BusinessException(ResponseCode.INVALID_REQUEST, "해당하는 멤버가 존재하지 않습니다."));
-
-		clubValidator.validateOwnerAndAdminRole(findClubMember.getClubMemberRole());
-
 		return joinRequestRepository.findJoinRequestByClubId(clubId, pageable);
 	}
 
@@ -149,7 +143,10 @@ public class JoinServiceImpl implements JoinService {
 		ClubMember findClubMember = clubMemberRepository.findByClubIdAndUserId(clubId, userId)
 			.orElseThrow(() -> new BusinessException(ResponseCode.ACCESS_DENIED, "접근할 수 없습니다."));
 
-		clubValidator.validateOwnerAndAdminRole(findClubMember.getClubMemberRole());
+		if (findClubMember.getClubMemberRole() != ClubMemberRole.OWNER
+			&& findClubMember.getClubMemberRole() != ClubMemberRole.ADMIN) {
+			throw new BusinessException(ResponseCode.ACCESS_DENIED, "클랜장과 운영진만 조회 가능합니다.");
+		}
 
 		return infoJoinRequestResponseDto;
 	}
@@ -226,17 +223,25 @@ public class JoinServiceImpl implements JoinService {
 	 */
 	private void validateJoinRequest(Club club, User user) {
 		// 1. 중복 신청 조회
-		boolean alreadyRequested = joinRequestRepository.existsJoinByClubIdAndUserId(club.getId(), user.getId());
-		if (alreadyRequested) {
-			throw new BusinessException(ResponseCode.INVALID_REQUEST, "이미 가입 신청한 클럽입니다.");
-		}
 		Optional<JoinRequest> alreadyRequested = joinRequestRepository.findJoinByClubIdAndUserId(club.getId(),
 			user.getId());
 
+		alreadyRequested.ifPresent(joinRequest -> {
+			if (joinRequest.getJoinStatus() == JoinStatus.PENDING
+				|| joinRequest.getJoinStatus() == JoinStatus.APPROVED) {
+				throw new BusinessException(ResponseCode.INVALID_REQUEST, "이미 가입 신청한 클럽입니다.");
+			}
+		});
+
 		// 2. 이미 가입된 유저인지 조회
-		if (clubMemberRepository.findByClubIdAndUserId(club.getId(), user.getId()).isPresent()) {
-			throw new BusinessException(ResponseCode.INVALID_REQUEST, "이미 가입된 클럽입니다.");
-		}
+		clubMemberRepository.findByClubAndUserWithAnyStatus(club, user).ifPresent(
+			clubMember -> {
+				switch(clubMember.getClubMemberStatus()) {
+					case ACTIVE: throw new BusinessException(ResponseCode.INVALID_REQUEST, "이미 가입 신청한 클럽입니다.");
+					case KICKED: throw new BusinessException(ResponseCode.INVALID_REQUEST, "강퇴한 당한 클럽은 가입 불가합니다.");
+				}
+			}
+		);
 
 		// 3. 클럽원 다 찼는지 확인
 		if (clubMemberRepository.countByClubIdAndStatus(club.getId(), ClubMemberStatus.ACTIVE)

--- a/src/main/java/com/example/cluvrapi/domain/join/service/JoinServiceImpl.java
+++ b/src/main/java/com/example/cluvrapi/domain/join/service/JoinServiceImpl.java
@@ -178,9 +178,8 @@ public class JoinServiceImpl implements JoinService {
 			throw new BusinessException(ResponseCode.ACCESS_DENIED, "신청한 본인만 취소할 수 있습니다.");
 		}
 
-		// 2) Join Status 를 Cancel 로 수정
-		findJoinRequest.updateJoinStatus();
-		joinRequestRepository.delete(findJoinRequest);
+		// 2) Join Status 를 SoftDeleted
+		findJoinRequest.delete();
 
 		// 3) JoinRequest Answer 이 존재한다면, 삭제
 		joinRequestRepository.findJoinRequestAnswerByIdAndClubId(clubId, joinRequestId)


### PR DESCRIPTION
<!-- 
꼭 제목을 아래와 같은 형식으로 변경해주세요 !
Feat/#24:board-crud

: <- 이거 잊으시면 안 됩니다!
-->

## 📌 개요

<!-- 어떤 작업을 했는지 한 줄로 요약해주세요. -->
가입 요청과 클럽멤버이 일관성 있게 처리되고자 리팩토링 햇습니다.
그 밖의 코드 가독성 개선 및 주석을 추가했습니다.

---

## 🔍 관련 이슈

<!-- 연결된 이슈가 있다면 닫히도록 설정해주세요. -->

- Closes #168

---

## PR 천천히 해주세요 : > !!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서화**
  * 클럽 멤버 관련 컨트롤러, 엔티티, 서비스, enum에 상세한 Javadoc 주석이 추가되었습니다.

* **리팩터**
  * 클럽 가입 요청 처리 방식이 단순 enum 전달에서 DTO 객체 전달로 변경되었습니다.
  * 가입 요청 승인/거절 로직이 switch 문과 별도 메서드로 구조화되었습니다.
  * 기존의 외부 검증기 의존성이 제거되고, 인라인 권한 체크로 대체되었습니다.

* **버그 수정**
  * 가입 요청 취소 시 하드 삭제에서 소프트 삭제(플래그 처리)로 변경되었습니다.
  * 중복 가입 요청 및 멤버 상태에 따른 예외 처리가 개선되었습니다.

* **기능 변경**
  * 가입 요청 상태 enum에서 CANCELED가 제거되었습니다.
  * 가입 요청 관련 메서드가 존재 여부 반환에서 실제 엔티티 반환으로 변경되었습니다.
  * 가입 요청 승인, 거절, 삭제를 위한 별도의 메서드가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->