### PR TITLE
Feat/#195 : email 인증 제외한 회원가입

### DIFF
--- a/src/main/java/com/example/cluvrapi/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/cluvrapi/domain/auth/controller/AuthController.java
@@ -7,6 +7,7 @@ import jakarta.validation.Valid;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -79,7 +80,7 @@ public class AuthController {
 			));
 	}
 
-
+	@Profile({"local", "test"})
 	@PostMapping("/test-signup")
 	public ResponseEntity<BaseResponse<SignUpUserResponseDto>> simpleSignUp(
 		@Valid @RequestBody SignUpUserRequestDto dto) {

--- a/src/main/java/com/example/cluvrapi/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/cluvrapi/domain/auth/service/AuthServiceImpl.java
@@ -119,7 +119,7 @@ public class AuthServiceImpl implements AuthService {
 
 		redisTemplate.opsForValue().set(key, cacheDto, VERIFY_TTL);
 		SimpleMailMessage msg = new SimpleMailMessage();
-		msg.setFrom(dto.getEmail());
+		msg.setFrom(mailFrom);
 		msg.setTo(emailLower);
 		msg.setSubject("【Cluvr】 회원가입 인증번호 안내");
 		msg.setText(
@@ -231,7 +231,16 @@ public class AuthServiceImpl implements AuthService {
 			.token(refreshToken)
 			.build();
 
-		cognitoUserClient.revokeToken(revokeTokenRequest);
+		try {
+			cognitoUserClient.revokeToken(revokeTokenRequest);
+			log.info(" Refresh token 사라짐");
+		} catch (CognitoIdentityProviderException e) {
+			log.error(" Cognito 에러 발생: {}", e.awsErrorDetails().errorMessage());
+			throw e;
+		} catch (Exception e) {
+			log.error(" 일반 예외 발생", e);
+			throw e;
+		}
 	}
 
 	private String calculateSecretHash(String clientId, String clientSecret, String username) {
@@ -392,6 +401,40 @@ public class AuthServiceImpl implements AuthService {
 			throw new BusinessException(ResponseCode.INVALID_REQUEST, "비밀번호와 확인이 일치하지 않습니다.");
 		}
 
+		//바로 cognito 가입 & 확인
+		try {
+			String username = dto.getEmail();
+			cognitoUserClient.signUp(SignUpRequest.builder()
+				.clientId(clientId)
+				.username(username)
+				.password(dto.getPassword())
+				.secretHash(calculateSecretHash(clientId, clientSecret, username))
+				.userAttributes(List.of(
+					AttributeType.builder().name("email").value(dto.getEmail()).build(),
+					AttributeType.builder().name("name").value(dto.getName()).build()
+				))
+				.build());
+
+			cognitoAdminClient.adminConfirmSignUp(AdminConfirmSignUpRequest.builder()
+				.userPoolId(userPoolId)
+				.username(username)
+				.build());
+
+			cognitoAdminClient.adminUpdateUserAttributes(AdminUpdateUserAttributesRequest.builder()
+				.userPoolId(userPoolId)
+				.username(username)
+				.userAttributes(AttributeType.builder()
+					.name("email_verified")
+					.value("true")
+					.build())
+				.build());
+		} catch (UsernameExistsException e) {
+			throw new BusinessException(ResponseCode.ALREADY_COGNITO);
+		} catch (CognitoIdentityProviderException e) {
+			log.error("cognito 등록이 안됨 사유 : {}", e.awsErrorDetails().errorMessage(), e);
+			throw new BusinessException(ResponseCode.INTERNAL_ERROR);
+		}
+
 		AuthenticationResultType authResult = cognitoUserClient
 			.adminInitiateAuth(builder -> builder
 				.authFlow(AuthFlowType.ADMIN_NO_SRP_AUTH)
@@ -407,13 +450,18 @@ public class AuthServiceImpl implements AuthService {
 		Jwt jwt = jwtDecoder.decode(authResult.idToken());
 		String sub = jwt.getSubject();
 
+		// 로컬 DB 저장
+		String domain = emailLower.substring(emailLower.indexOf('@') + 1);
+		UserRole role = appProperties.getAdminDomains().contains(domain)
+			? UserRole.ADMIN : UserRole.USER;
+
 		User user = new User(
 			null,                        // id (자동 생성)
 			dto.getName(),
 			dto.getBirthday(),
 			emailLower,
 			dto.getPhoneNumber(),
-			UserRole.USER,               // 기본 USER 권한
+			role,            // 기본 USER 권한
 			dto.getGender(),
 			dto.getCategoryType(),
 			passwordEncoder.encode(dto.getPassword()),

--- a/src/main/java/com/example/cluvrapi/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/example/cluvrapi/domain/notice/controller/NoticeController.java
@@ -28,7 +28,7 @@ import com.example.cluvrapi.global.response.BaseResponse;
 import com.example.cluvrapi.global.response.ResponseCode;
 
 @RestController
-@RequestMapping("/clubs/{clubId}/notices")
+@RequestMapping("api/clubs/{clubId}/notices")
 @RequiredArgsConstructor
 public class NoticeController {
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,8 @@ server:
     include-message: always
   port: 80
 spring:
+  profiles:
+    active: local
   security:
     oauth2:
       resourceserver:
@@ -88,5 +90,6 @@ logging:
   level:
     root: INFO
     software.amazon.awssdk: DEBUG
+    software.amazon.awssdk.auth: DEBUG
     com.amazonaws: DEBUG
     com.example.cluvrapi: DEBUG


### PR DESCRIPTION

## 📌 개요

회원가입 시에 , 테스트 용으로 이메일인증을 제외한 서비스 및 컨트롤러
---

## 🔍 관련 이슈



- Closes #195 
---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 회원가입 인증 이메일 발신자가 사용자 이메일에서 시스템 이메일로 변경되었습니다.
  * 로그아웃 시 토큰 만료 처리의 오류 로그 및 예외 처리가 개선되었습니다.

* **신규 기능**
  * 테스트 회원가입 시 Cognito 사용자 등록 및 즉시 인증, 이메일 인증 처리, 이메일 도메인에 따른 관리자/사용자 역할 자동 할당이 추가되었습니다.

* **스타일/구성**
  * 공지사항 API 경로가 `api/clubs/{clubId}/notices`로 변경되었습니다.
  * `/test-signup` 엔드포인트가 "local" 또는 "test" 프로필에서만 활성화됩니다.
  * 기본 활성 Spring 프로필이 "local"로 설정되고, AWS SDK 인증 관련 로그 레벨이 DEBUG로 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->