### PR TITLE
Refactor/#243:Lock 등록 이후 캐시 등록&캐시 시간 연장

### DIFF
--- a/src/main/java/com/example/cluvrapi/domain/join/service/lock/DirectJoinLockAspect.java
+++ b/src/main/java/com/example/cluvrapi/domain/join/service/lock/DirectJoinLockAspect.java
@@ -64,9 +64,6 @@ public class DirectJoinLockAspect {
 			throw new IllegalStateException("이미 처리 중인 요청입니다.");
 		}
 
-		// 캐시 등록 (중복 방지)
-		bucket.set(true, 6, TimeUnit.SECONDS);
-
 		RLock lock = redissonClient.getLock(lockKey);
 		boolean isLocked = false;
 
@@ -75,6 +72,9 @@ public class DirectJoinLockAspect {
 			if (!isLocked) {
 				throw new IllegalStateException("락 획득 실패: key = " + lockKey);
 			}
+
+			// 캐시 등록 (중복 방지)
+			bucket.set(true, 30, TimeUnit.SECONDS);
 
 			log.info("락 획득 성공: key = {}", lockKey);
 


### PR DESCRIPTION
<!-- 
꼭 제목을 아래와 같은 형식으로 변경해주세요 !
Feat/#24:board-crud

: <- 이거 잊으시면 안 됩니다!
-->

## 📌 개요

<!-- 어떤 작업을 했는지 한 줄로 요약해주세요. -->
ex) 로그인 기능 추가

---

## 🔍 관련 이슈

<!-- 연결된 이슈가 있다면 닫히도록 설정해주세요. -->

- Closes #243

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 중복 요청 방지를 위한 캐시 등록 시점을 조정하여, 락 획득 이후에만 캐시가 등록되도록 변경되었습니다.  
  * 캐시 만료 시간이 6초에서 30초로 연장되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->